### PR TITLE
Add wallet sync

### DIFF
--- a/rpc/.gitignore
+++ b/rpc/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /.localnet
 /target
+*.iml

--- a/rpc/Cargo.lock
+++ b/rpc/Cargo.lock
@@ -493,6 +493,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "drop-stream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3ad5e2193e855cdd101d6d4ad09f0b3fa9aa5bd5169f483b4accd6eef96cfe"
+dependencies = [
+ "futures-core",
+ "pin-project",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,6 +1211,7 @@ dependencies = [
  "bdk_bitcoind_rpc",
  "bdk_wallet",
  "clap",
+ "drop-stream",
  "futures",
  "musig2",
  "prost",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/client.rs"
 bdk_bitcoind_rpc = "0.18.0"
 bdk_wallet = "1.1.0"
 clap = { version = "4.5.31", features = ["derive"] }
+drop-stream = "0.3.2"
 futures = "0.3.31"
 musig2 = { version = "0.2.3", features = ["rand"] }
 prost = "0.13.4"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -34,12 +34,15 @@ pedantic = "warn"
 # Enable selected 'nursery' and 'restriction' lints...
 allow_attributes = "warn"
 allow_attributes_without_reason = "warn"
+branches_sharing_code = "warn"
 iter_on_single_items = "warn"
 iter_on_empty_collections = "warn"
+missing_const_for_fn = "warn"
 renamed_function_params = "warn"
 significant_drop_tightening = "warn"
 str_to_string = "warn"
 try_err = "warn"
 unused_trait_names = "warn"
+use_self = "warn"
 # Format arg handling in IDEA Rust plugin is broken:
 uninlined_format_args = { level = "allow", priority = 1 }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -45,5 +45,3 @@ str_to_string = "warn"
 try_err = "warn"
 unused_trait_names = "warn"
 use_self = "warn"
-# Format arg handling in IDEA Rust plugin is broken:
-uninlined_format_args = { level = "allow", priority = 1 }

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -16,12 +16,15 @@ See [MuSig trade protocol messages](musig-trade-protocol-messages.txt) for my cu
 trade messages between the peers would look like, and thus the necessary data to exchange in an RPC interface between
 the Bisq2 client and the Rust server managing the wallet and key material.
 
-### Experimental wallet gRPC interface and test CLI
+### Experimental wallet gRPC interface and test CLI + Java client
 
 To help test and develop the wallet and chain notification API that will be needed by Bisq, a small Rust gRPC client
 with a command-line interface is also included as a binary target (`musig-cli`). Currently, this is providing access to
 a handful of experimental wallet RPC endpoints that will talk to BDK to get account balance, UTXO set, block reorg
 notifications, etc. (only partially implemented).
+
+A non-interactive Java test gRPC client has also been written to query the UTXO set, then open an RPC stream for each
+UTXO and listen for confidence updates (confirmations, reorgs, etc.), running for a few seconds.
 
 The wallet is currently just hardwired to use _regtest_, without persistence. It uses the `bdk_bitcoind_rpc`
 crate to talk to a local `bitcoind` instance via JSON-RPC on port 18443, authenticated with cookies and with
@@ -60,4 +63,10 @@ cargo run
 
 ```sh
 mvn install exec:java
+```
+
+5. To subsequently run the Java test client for the wallet gRPC interface, run:
+
+```sh
+mvn exec:java -Pwallet
 ```

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -28,8 +28,8 @@ UTXO and listen for confidence updates (confirmations, reorgs, etc.), running fo
 
 The wallet is currently just hardwired to use _regtest_, without persistence. It uses the `bdk_bitcoind_rpc`
 crate to talk to a local `bitcoind` instance via JSON-RPC on port 18443, authenticated with cookies and with
-data-dir `$PWD/.localnet/bitcoind`. It does a full scan once upon startup, with continual syncing yet to be implemented.
-A `bitcoind` regtest instance may be started up as follows, from the PWD:
+data-dir `$PWD/.localnet/bitcoind`. It does a full scan once upon startup, then polls once per second. A `bitcoind`
+regtest instance may be started up as follows, from the PWD:
 
 ```sh
 bitcoind -regtest -prune=0 -txindex=1 -blockfilterindex=1 -server -datadir=.localnet/bitcoind

--- a/rpc/build.rs
+++ b/rpc/build.rs
@@ -1,5 +1,3 @@
-use std::prelude::rust_2021::*;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure().compile_protos(
         &["src/main/proto/rpc.proto", "src/main/proto/wallet.proto"],

--- a/rpc/pom.xml
+++ b/rpc/pom.xml
@@ -67,8 +67,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>22</source>
+                    <target>22</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -93,6 +93,21 @@
                         <version>3.5.0</version>
                         <configuration>
                             <mainClass>bisq.TradeProtocolClient</mainClass>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>wallet</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <configuration>
+                            <mainClass>bisq.WalletClient</mainClass>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -2,7 +2,6 @@ mod walletrpc;
 
 use bdk_wallet::bitcoin::hashes::{Hash as _, sha256d};
 use clap::{Parser, Subcommand};
-use std::prelude::rust_2021::*;
 use tokio_stream::StreamExt as _;
 use tonic::Request;
 
@@ -39,17 +38,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::WalletBalance => {
             let response = client.wallet_balance(Request::new(WalletBalanceRequest {})).await?;
             drop(client);
-            println!("{:#?}", response);
+            println!("{response:#?}");
         }
         Commands::NewAddress => {
             let response = client.new_address(Request::new(NewAddressRequest {})).await?;
             drop(client);
-            println!("{:#?}", response);
+            println!("{response:#?}");
         }
         Commands::ListUnspent => {
             let response = client.list_unspent(Request::new(ListUnspentRequest {})).await?;
             drop(client);
-            println!("{:?}", response);
+            println!("{response:?}");
         }
         Commands::NotifyConfidence { tx_id } => {
             let tx_id = tx_id.parse::<sha256d::Hash>()?.as_byte_array().to_vec();

--- a/rpc/src/main/java/bisq/TradeProtocolClient.java
+++ b/rpc/src/main/java/bisq/TradeProtocolClient.java
@@ -17,11 +17,13 @@ public class TradeProtocolClient {
                 InsecureChannelCredentials.create()
         ).build();
 
-        var musigStub = MusigGrpc.newBlockingStub(channel);
-        testMusigService_twoParties(musigStub, 0, ClosureType.COOPERATIVE);
-        testMusigService_twoParties(musigStub, 1, ClosureType.UNCOOPERATIVE);
-
-        channel.shutdown();
+        try {
+            var musigStub = MusigGrpc.newBlockingStub(channel);
+            testMusigService_twoParties(musigStub, 0, ClosureType.COOPERATIVE);
+            testMusigService_twoParties(musigStub, 1, ClosureType.UNCOOPERATIVE);
+        } finally {
+            channel.shutdown();
+        }
     }
 
     /**

--- a/rpc/src/main/java/bisq/WalletClient.java
+++ b/rpc/src/main/java/bisq/WalletClient.java
@@ -1,0 +1,52 @@
+package bisq;
+
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
+import io.grpc.StatusRuntimeException;
+import walletrpc.WalletGrpc;
+import walletrpc.WalletOuterClass.ConfRequest;
+import walletrpc.WalletOuterClass.ListUnspentRequest;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class WalletClient {
+    public static void main(String[] args) throws InterruptedException {
+        var channel = Grpc.newChannelBuilderForAddress(
+                "127.0.0.1",
+                50051,
+                InsecureChannelCredentials.create()
+        ).build();
+
+        try {
+            var walletStub = WalletGrpc.newBlockingStub(channel);
+
+            System.out.println("Requesting wallet UTXOs.");
+            var utxos = walletStub.listUnspent(ListUnspentRequest.newBuilder().build()).getUtxosList();
+            utxos.forEach(o -> System.out.println("Got UTXO: " + o));
+
+            System.out.println("Opening tx confidence streams for UTXOs and waiting 5 seconds for events...");
+            try (var service = Executors.newVirtualThreadPerTaskExecutor()) {
+                var tasks = utxos.stream()
+                        .map(o -> Executors.callable(() -> {
+                            var confRequest = ConfRequest.newBuilder().setTxId(o.getTxId()).buildPartial();
+                            try {
+                                walletStub.registerConfidenceNtfn(confRequest)
+                                        .forEachRemaining(event -> System.out.println("Got event: " + event));
+                            } catch (StatusRuntimeException e) {
+                                System.out.println("Got exception: " + e);
+                            }
+                        }))
+                        .collect(Collectors.toList());
+
+                service.invokeAll(tasks, 5, TimeUnit.SECONDS);
+            }
+            System.out.println("Closed tx confidence stream. Channel still open. Waiting 5 more seconds...");
+            TimeUnit.SECONDS.sleep(5);
+        } finally {
+            System.out.println("Closing channel.");
+            channel.shutdown();
+        }
+    }
+}

--- a/rpc/src/main/proto/wallet.proto
+++ b/rpc/src/main/proto/wallet.proto
@@ -48,15 +48,16 @@ message ConfRequest {
 }
 
 message ConfEvent {
-  bytes rawTx = 1;
+  optional bytes rawTx = 1;
   ConfidenceType confidenceType = 2;
   uint32 numConfirmations = 3;
   optional ConfirmationBlockTime confirmationBlockTime = 4;
 }
 
 enum ConfidenceType {
-  CONFIRMED = 0;
+  MISSING = 0; // used as default; MUST have index 0
   UNCONFIRMED = 1;
+  CONFIRMED = 2;
 }
 
 message ConfirmationBlockTime {

--- a/rpc/src/observable.rs
+++ b/rpc/src/observable.rs
@@ -1,0 +1,122 @@
+use std::borrow::Borrow;
+use std::collections::{HashMap, HashSet};
+use std::collections::hash_map::Entry;
+use std::hash::Hash;
+use std::prelude::rust_2021::*;
+use tokio::sync::mpsc;
+use tokio_stream::Stream;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+
+#[derive(Default)]
+pub struct Observable<T> {
+    value: T,
+    senders: Vec<mpsc::UnboundedSender<T>>,
+}
+
+struct StillObservedError<T>(Observable<T>);
+
+impl<T> Observable<T> {
+    pub const fn new(value: T) -> Self {
+        Self { value, senders: Vec::new() }
+    }
+
+    fn try_into_unobserved(mut self) -> Result<T, StillObservedError<T>> {
+        self.senders.retain(|s| !s.is_closed());
+        if self.senders.is_empty() { Ok(self.value) } else { Err(StillObservedError(self)) }
+    }
+}
+
+impl<T: Clone> Observable<T> {
+    pub fn observe(&mut self) -> impl Stream<Item=T> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        tx.send(self.value.clone()).unwrap();
+        self.senders.push(tx);
+        UnboundedReceiverStream::new(rx)
+    }
+}
+
+impl<T: Clone + PartialEq> Observable<T> {
+    pub fn replace(&mut self, value: T) -> T {
+        let old_value = std::mem::replace(&mut self.value, value);
+        let new_value = &self.value;
+        if old_value == *new_value {
+            self.senders.retain(|s| !s.is_closed());
+        } else {
+            self.senders.retain(|s| s.send(new_value.clone()).is_ok());
+        }
+        old_value
+    }
+}
+
+impl<T: Clone + Default + PartialEq> Observable<T> {
+    pub fn take(&mut self) -> T { self.replace(T::default()) }
+}
+
+pub struct ObservableHashMap<K, V> {
+    map: HashMap<K, Observable<Option<V>>>,
+}
+
+impl<K, V> Default for ObservableHashMap<K, V> {
+    fn default() -> Self { Self { map: HashMap::default() } }
+}
+
+impl<K, V> ObservableHashMap<K, V> {
+    pub fn new() -> Self { Self::default() }
+}
+
+impl<K, V> ObservableHashMap<K, V>
+    where K: Eq + Hash,
+          V: Clone
+{
+    pub fn observe(&mut self, key: K) -> impl Stream<Item=Option<V>> {
+        match self.map.entry(key) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(Observable::default())
+        }.observe()
+    }
+}
+
+impl<K, V> ObservableHashMap<K, V>
+    where K: Eq + Hash,
+          V: Clone + PartialEq
+{
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        match self.map.entry(key) {
+            Entry::Occupied(entry) =>
+                entry.into_mut().replace(Some(value)),
+            Entry::Vacant(entry) => {
+                entry.insert(Observable::new(Some(value)));
+                None
+            }
+        }
+    }
+
+    pub fn remove<Q>(&mut self, k: &Q) -> Option<V>
+        where K: Borrow<Q>,
+              Q: Eq + Hash + ?Sized
+    {
+        let (key, observed_value) = self.map.remove_entry(k)?;
+        observed_value.try_into_unobserved()
+            .unwrap_or_else(|StillObservedError(mut o)| {
+                let taken = o.take();
+                self.map.insert(key, o);
+                taken
+            })
+    }
+}
+
+impl<K, V> ObservableHashMap<K, V>
+    where K: Clone + Eq + Hash,
+          V: Clone + PartialEq
+{
+    pub fn sync(&mut self, entries: impl IntoIterator<Item=(K, V)>) {
+        let mut remaining_keys: HashSet<K> = self.map.keys().cloned().collect();
+        for (key, value) in entries {
+            remaining_keys.remove(&key);
+            self.insert(key, value);
+        }
+        for key in remaining_keys {
+            self.remove(&key);
+        }
+    }
+}

--- a/rpc/src/observable.rs
+++ b/rpc/src/observable.rs
@@ -2,7 +2,6 @@ use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry;
 use std::hash::Hash;
-use std::prelude::rust_2021::*;
 use tokio::sync::mpsc;
 use tokio_stream::Stream;
 use tokio_stream::wrappers::UnboundedReceiverStream;

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -344,16 +344,14 @@ impl TradeModel {
             self.buyers_warning_tx_buyer_input_sig_ctx.peers_partial_sig = Some(sigs.peers_warning_tx_buyer_input_partial_signature);
             self.buyers_warning_tx_seller_input_sig_ctx.peers_partial_sig = Some(sigs.peers_warning_tx_seller_input_partial_signature);
             self.buyers_redirect_tx_input_sig_ctx.peers_partial_sig = Some(sigs.peers_redirect_tx_input_partial_signature);
-            self.swap_tx_input_sig_ctx.peers_partial_sig = sigs.swap_tx_input_partial_signature;
         } else {
             self.sellers_warning_tx_buyer_input_sig_ctx.peers_partial_sig = Some(sigs.peers_warning_tx_buyer_input_partial_signature);
             self.sellers_warning_tx_seller_input_sig_ctx.peers_partial_sig = Some(sigs.peers_warning_tx_seller_input_partial_signature);
             self.sellers_redirect_tx_input_sig_ctx.peers_partial_sig = Some(sigs.peers_redirect_tx_input_partial_signature);
-
-            // NOTE: The passed field here would normally be 'None'. The buyer should redact the field at the trade
-            // start and reveal it later, after payment is started, to prevent premature trade closure by the seller:
-            self.swap_tx_input_sig_ctx.peers_partial_sig = sigs.swap_tx_input_partial_signature;
         }
+        // NOTE: This passed field would normally be 'None' for the seller, as the buyer should redact the field
+        // at the trade start and reveal it later, after payment is started, to prevent premature trade closure:
+        self.swap_tx_input_sig_ctx.peers_partial_sig = sigs.swap_tx_input_partial_signature;
     }
 
     pub fn aggregate_partial_signatures(&mut self) -> Result<()> {

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -5,7 +5,6 @@ use musig2::{AggNonce, KeyAggContext, LiftedSignature, NonceSeed, PartialSignatu
 use musig2::adaptor::AdaptorSignature;
 use secp::{MaybePoint, MaybeScalar, Point, Scalar};
 use std::collections::BTreeMap;
-use std::prelude::rust_2021::*;
 use std::sync::{Arc, LazyLock, Mutex};
 use thiserror::Error;
 
@@ -180,6 +179,7 @@ impl TradeModel {
         Ok(())
     }
 
+    //noinspection SpellCheckingInspection
     pub fn init_my_fee_bump_addresses(&mut self) -> Result<()> {
         // TODO: Replace dummy addresses with real ones provided by a service, say by passing in a
         //  suitable service or context object. (Need to make the network configurable as well.)

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -349,7 +349,7 @@ impl<T, S: MyTryInto<T>> MyTryInto<Option<T>> for Option<S> {
 
 impl From<ExchangedNonces<'_, ByRef>> for NonceSharesMessage {
     fn from(value: ExchangedNonces<ByRef>) -> Self {
-        NonceSharesMessage {
+        Self {
             // Use default values for proto fields besides the nonce shares. TODO: A little hacky; consider refactoring proto.
             warning_tx_fee_bump_address: String::default(),
             redirect_tx_fee_bump_address: String::default(),
@@ -396,7 +396,7 @@ impl<'a> MyTryInto<ExchangedNonces<'a, ByVal>> for NonceSharesMessage {
 
 impl From<ExchangedSigs<'_, ByRef>> for PartialSignaturesMessage {
     fn from(value: ExchangedSigs<ByRef>) -> Self {
-        PartialSignaturesMessage {
+        Self {
             peers_warning_tx_buyer_input_partial_signature:
             value.peers_warning_tx_buyer_input_partial_signature.serialize().into(),
             peers_warning_tx_seller_input_partial_signature:
@@ -426,7 +426,7 @@ impl<'a> MyTryInto<ExchangedSigs<'a, ByVal>> for PartialSignaturesMessage {
 
 impl From<Balance> for WalletBalanceResponse {
     fn from(value: Balance) -> Self {
-        WalletBalanceResponse {
+        Self {
             immature: value.immature.to_sat(),
             trusted_pending: value.trusted_pending.to_sat(),
             untrusted_pending: value.untrusted_pending.to_sat(),
@@ -437,7 +437,7 @@ impl From<Balance> for WalletBalanceResponse {
 
 impl From<LocalOutput> for TransactionOutput {
     fn from(value: LocalOutput) -> Self {
-        TransactionOutput {
+        Self {
             tx_id: value.outpoint.txid.as_byte_array().into(),
             vout: value.outpoint.vout,
             script_pub_key: value.txout.script_pubkey.into_bytes(),
@@ -459,7 +459,7 @@ impl From<TxConfidence> for ConfEvent {
                 })),
             ChainPosition::Unconfirmed { .. } => (ConfidenceType::Unconfirmed, None)
         };
-        ConfEvent {
+        Self {
             raw_tx,
             confidence_type: confidence_type.into(),
             num_confirmations,

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -21,7 +21,6 @@ use prost::UnknownEnumValue;
 use secp::{Point, MaybeScalar, Scalar};
 use std::iter;
 use std::marker::{Send, Sync};
-use std::prelude::rust_2021::*;
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
 use tonic::transport::Server;
@@ -227,7 +226,7 @@ impl wallet_server::Wallet for WalletImpl {
         let txid = request.into_inner().tx_id.my_try_into()?;
         let conf_events = self.wallet_service.get_tx_confidence_stream(txid)
             .map(move |o| Ok(o
-                .ok_or_else(|| Status::not_found(format!("could not find wallet tx with id: {}", txid)))?
+                .ok_or_else(|| Status::not_found(format!("could not find wallet tx with id: {txid}")))?
                 .into()))
             .boxed();
 
@@ -257,7 +256,7 @@ impl_musig_req!(CloseTradeRequest);
 fn handle_request<Req, Res, F>(request: Request<Req>, handler: F) -> Result<Response<Res>>
     where Req: MusigRequest,
           F: FnOnce(Req, &mut TradeModel) -> Result<Res> {
-    println!("Got a request: {:?}", request);
+    println!("Got a request: {request:?}");
 
     let request = request.into_inner();
     let trade_model = TRADE_MODELS.get_trade_model(request.trade_id())
@@ -315,7 +314,7 @@ impl MyTryInto<Txid> for &[u8] {
 impl MyTryInto<Role> for i32 {
     fn my_try_into(self) -> Result<Role> {
         TryInto::<musigrpc::Role>::try_into(self)
-            .map_err(|UnknownEnumValue(i)| Status::out_of_range(format!("unknown enum value: {}", i)))
+            .map_err(|UnknownEnumValue(i)| Status::out_of_range(format!("unknown enum value: {i}")))
             .map(Into::into)
     }
 }
@@ -323,7 +322,7 @@ impl MyTryInto<Role> for i32 {
 impl MyTryInto<Address<NetworkUnchecked>> for &str {
     fn my_try_into(self) -> Result<Address<NetworkUnchecked>> {
         self.parse::<Address<_>>()
-            .map_err(|e| Status::invalid_argument(format!("could not parse address: {}", e)))
+            .map_err(|e| Status::invalid_argument(format!("could not parse address: {e}")))
     }
 }
 

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -1,3 +1,4 @@
+mod observable;
 mod protocol;
 mod storage;
 mod wallet;
@@ -225,8 +226,9 @@ impl wallet_server::Wallet for WalletImpl {
 
         let txid = request.into_inner().tx_id.my_try_into()?;
         let conf_events = self.wallet_service.get_tx_confidence_stream(txid)
-            .ok_or_else(|| Status::not_found(format!("could not find wallet tx with id: {}", txid)))?
-            .map(|o| Ok(o.into()))
+            .map(move |o| Ok(o
+                .ok_or_else(|| Status::not_found(format!("could not find wallet tx with id: {}", txid)))?
+                .into()))
             .boxed();
 
         Ok(Response::new(conf_events))

--- a/rpc/src/storage.rs
+++ b/rpc/src/storage.rs
@@ -1,4 +1,4 @@
-use std::convert::Infallible;
+use futures::never::Never;
 
 /// A simple utility trait to allow structs to be polymorphic over the storage type of their fields,
 /// to facilitate passing data to and from functions by reference or value, decided statically for
@@ -15,13 +15,13 @@ pub trait ValStorage {
 }
 
 /// Hold the struct fields by reference.
-pub struct ByRef(Infallible);
+pub struct ByRef(Never);
 
 /// Hold the struct fields by value.
-pub struct ByVal(Infallible);
+pub struct ByVal(Never);
 
 /// Hold the struct fields by Option-wrapped value.
-pub struct ByOptVal(Infallible);
+pub struct ByOptVal(Never);
 
 impl Storage for ByRef {
     // It isn't ideal to make the lifetime a type parameter here, instead of making it a parameter

--- a/rpc/src/storage.rs
+++ b/rpc/src/storage.rs
@@ -1,5 +1,4 @@
 use std::convert::Infallible;
-use std::prelude::rust_2021::*;
 
 /// A simple utility trait to allow structs to be polymorphic over the storage type of their fields,
 /// to facilitate passing data to and from functions by reference or value, decided statically for

--- a/rpc/src/wallet.rs
+++ b/rpc/src/wallet.rs
@@ -27,13 +27,13 @@ pub struct WalletServiceImpl {
 }
 
 impl WalletServiceImpl {
-    pub fn new() -> WalletServiceImpl {
+    pub fn new() -> Self {
         let wallet: Wallet = Wallet::create(EXTERNAL_DESCRIPTOR, INTERNAL_DESCRIPTOR)
             .network(Network::Regtest)
             .create_wallet_no_persist()
             .unwrap();
 
-        WalletServiceImpl { wallet: RwLock::new(wallet) }
+        Self { wallet: RwLock::new(wallet) }
     }
 }
 
@@ -104,6 +104,6 @@ pub struct WalletTx {
 
 impl From<bdk_wallet::WalletTx<'_>> for WalletTx {
     fn from(value: bdk_wallet::WalletTx) -> Self {
-        WalletTx { tx: value.tx_node.tx, chain_position: value.chain_position }
+        Self { tx: value.tx_node.tx, chain_position: value.chain_position }
     }
 }

--- a/rpc/src/wallet.rs
+++ b/rpc/src/wallet.rs
@@ -1,18 +1,19 @@
+use bdk_bitcoind_rpc::Emitter;
+use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client, RpcApi as _};
 use bdk_wallet::{AddressInfo, Balance, KeychainKind, LocalOutput, Wallet};
 use bdk_wallet::bitcoin::{Network, Transaction, Txid};
 use bdk_wallet::chain::{CheckPoint, ChainPosition, ConfirmationBlockTime};
-use bdk_bitcoind_rpc::Emitter;
-use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client, RpcApi as _};
 use drop_stream::DropStream;
 use futures::stream::{BoxStream, StreamExt as _};
-use std::prelude::rust_2021::*;
 use std::sync::{Arc, Mutex, RwLock};
 
 use crate::observable::ObservableHashMap;
 
 const COOKIE_FILE_PATH: &str = ".localnet/bitcoind/regtest/.cookie";
+//noinspection SpellCheckingInspection
 const EXTERNAL_DESCRIPTOR: &str = "tr(tprv8ZgxMBicQKsPdrjwWCyXqqJ4YqcyG4DmKtjjsRt29v1PtD3r3PuFJAj\
     WytzcvSTKnZAGAkPSmnrdnuHWxCAwy3i1iPhrtKAfXRH7dVCNGp6/86'/1'/0'/0/*)#g9xn7wf9";
+//noinspection SpellCheckingInspection
 const INTERNAL_DESCRIPTOR: &str = "tr(tprv8ZgxMBicQKsPdrjwWCyXqqJ4YqcyG4DmKtjjsRt29v1PtD3r3PuFJAj\
     WytzcvSTKnZAGAkPSmnrdnuHWxCAwy3i1iPhrtKAfXRH7dVCNGp6/86'/1'/0'/1/*)#e3rjrmea";
 
@@ -110,7 +111,7 @@ impl WalletService for WalletServiceImpl {
 
     fn get_tx_confidence_stream(&self, txid: Txid) -> BoxStream<'static, Option<TxConfidence>> {
         DropStream::new(self.tx_confidence_map.lock().unwrap().observe(txid), move || {
-            println!("Confidence stream has been dropped for txid: {}", txid);
+            println!("Confidence stream has been dropped for txid: {txid}");
         }).boxed()
     }
 }

--- a/rpc/src/wallet.rs
+++ b/rpc/src/wallet.rs
@@ -3,6 +3,7 @@ use bdk_wallet::bitcoin::{Network, Transaction, Txid};
 use bdk_wallet::chain::{CheckPoint, ChainPosition, ConfirmationBlockTime};
 use bdk_bitcoind_rpc::Emitter;
 use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client, RpcApi as _};
+use drop_stream::DropStream;
 use futures::stream::{BoxStream, StreamExt as _};
 use std::prelude::rust_2021::*;
 use std::sync::{Arc, Mutex, RwLock};
@@ -108,7 +109,9 @@ impl WalletService for WalletServiceImpl {
     }
 
     fn get_tx_confidence_stream(&self, txid: Txid) -> BoxStream<'static, Option<TxConfidence>> {
-        self.tx_confidence_map.lock().unwrap().observe(txid).boxed()
+        DropStream::new(self.tx_confidence_map.lock().unwrap().observe(txid), move || {
+            println!("Confidence stream has been dropped for txid: {}", txid);
+        }).boxed()
     }
 }
 


### PR DESCRIPTION
Add polling logic to the BDK wallet component of the gRPC server, so that it continually polls the local _regtest_ bitcoind instance (once per second) for new transactions and blocks, instead of just doing an initial full scan upon startup. In this way, the `RegisterConfidenceNtfn` streaming RPC endpoint (and corresponding `notify-confidence` client CLI command) are made to stream continually looking for tx confirmations/broadcasts, instead of just returning a singleton stream of the current tx confidence which immediately closes. The RPC call is also made to work with unpublished txs, by returning "missing" confidence events instead of erroring if the provided txid is not found in the wallet. This allows it to double up as a subscription for both broadcast and confirmation events for txs with known ID, such as those of the trade protocol.

Also do some minor code cleanup (clippy lints plus redundant IDE plugin bug workarounds), and add another Java client entry point `bisq.WalletClient` runnable by calling

```sh
mvn exec:java -Pwallet
```

to test a couple of the wallet RPC service calls, including streaming.

(And update the README.)
