### PR TITLE
Upgrade protobuf for aarch64 compatibility

### DIFF
--- a/rpc/pom.xml
+++ b/rpc/pom.xml
@@ -49,9 +49,9 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.6.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.15.0:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:3.21.12:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.35.0:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.53.0:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
There is no aarch64 binary in 3.15.0. Upgrading to 3.21.12 which is the latest version that has an aarch64 binary and keeps full backwards compatibility.