### PR TITLE
Add more RPC integration tests and use Nigiri

### DIFF
--- a/rpc/.gitignore
+++ b/rpc/.gitignore
@@ -1,4 +1,5 @@
 /.idea
 /.localnet
+/.nigiri
 /target
 *.iml

--- a/rpc/Cargo.lock
+++ b/rpc/Cargo.lock
@@ -19,14 +19,14 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -304,9 +304,9 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.5"
+version = "0.32.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
+checksum = "ad8929a18b8e33ea6b3c09297b687baaa71fb1b97353243a3f1029fad5c59c5b"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
@@ -421,9 +421,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.21"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "shlex",
 ]
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -636,9 +636,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -783,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -967,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "musig2"
@@ -1292,7 +1292,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1484,6 +1484,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 name = "rpc"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "bdk_bitcoind_rpc",
  "bdk_wallet",
@@ -1718,12 +1719,12 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2096,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -2137,18 +2138,18 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -2252,31 +2253,11 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.25",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/rpc/Cargo.lock
+++ b/rpc/Cargo.lock
@@ -1502,7 +1502,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tonic",
  "tonic-build",
  "unimock",
@@ -1834,8 +1833,6 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "futures-util",
- "hashbrown 0.15.3",
  "pin-project-lite",
  "tokio",
 ]

--- a/rpc/Cargo.lock
+++ b/rpc/Cargo.lock
@@ -39,6 +39,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +381,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +406,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -433,6 +467,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +489,51 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -652,12 +737,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -680,6 +771,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"
@@ -806,6 +903,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +951,7 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]
@@ -835,6 +974,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "jsonrpc"
@@ -949,6 +1098,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,7 +1140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
@@ -1010,6 +1174,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1177,6 +1347,8 @@ dependencies = [
  "musig2",
  "prost",
  "rand",
+ "serde",
+ "serde_with",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -1294,6 +1466,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.9.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1597,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1501,7 +1734,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.9.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -1607,6 +1840,123 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/rpc/Cargo.lock
+++ b/rpc/Cargo.lock
@@ -156,9 +156,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
  "axum-core",
  "bytes",
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -421,9 +421,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "shlex",
 ]
@@ -436,9 +436,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -492,6 +492,26 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -562,6 +582,12 @@ dependencies = [
  "powerfmt",
  "serde",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "difflib"
@@ -775,9 +801,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -810,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heck"
@@ -840,6 +866,15 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "higher-kinded-types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "561985554c8b8d4808605c90a5f1979cc6c31a5d20b78465cd59501233c6678e"
+dependencies = [
+ "never-say-never",
+]
 
 [[package]]
 name = "hmac"
@@ -998,7 +1033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -1083,9 +1118,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniscript"
-version = "12.3.1"
+version = "12.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82911d2fb527bb9aacd2446d2f517aff3f8e3846ace1b3c24258b61ea3cce2bc"
+checksum = "0760e92feaf4ee26bd2e616f557de64712bf1e75f3b1b218dfb475c0a84c7943"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1144,6 +1179,12 @@ dependencies = [
  "sha2",
  "subtle",
 ]
+
+[[package]]
+name = "never-say-never"
+version = "6.6.666"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
 
 [[package]]
 name = "normalize-line-endings"
@@ -1230,6 +1271,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "polonius-the-crab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97ca2c89572ae41bbec1c99498251f87dd5a94e500c5ec19c382dd593dd5ce9"
+dependencies = [
+ "higher-kinded-types",
+ "never-say-never",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,7 +1292,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -1272,6 +1323,16 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -1427,12 +1488,14 @@ dependencies = [
  "bdk_bitcoind_rpc",
  "bdk_wallet",
  "clap",
+ "const_format",
  "drop-stream",
  "futures",
  "musig2",
  "predicates",
  "prost",
  "rand",
+ "rpc",
  "serde",
  "serde_with",
  "thiserror",
@@ -1441,6 +1504,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tonic-build",
+ "unimock",
 ]
 
 [[package]]
@@ -1451,9 +1515,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",
@@ -1583,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1637,9 +1701,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1724,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1770,16 +1834,16 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "tonic"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85839f0b32fd242bb3209262371d07feda6d780d16ee9d2bc88581b89da1549b"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
  "axum",
@@ -1806,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85f0383fadd15609306383a90e85eaed44169f931a5d2be1b42c76ceff1825e"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1897,6 +1961,35 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unimock"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738aeaf7498b9412d7603cb7094ef1a650becb31f868f1604b6cdc25b7fda09d"
+dependencies = [
+ "once_cell",
+ "polonius-the-crab",
+ "pretty_assertions",
+ "unimock_macros",
+]
+
+[[package]]
+name = "unimock_macros"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceeb88c851ae0273d9cd6bb9507def1fa5ed03eea7ca2c91adf4e82fb7a04995"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "utf8parse"
@@ -2152,6 +2245,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,11 +2261,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -2182,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rpc/Cargo.lock
+++ b/rpc/Cargo.lock
@@ -105,15 +105,31 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
 
 [[package]]
 name = "async-trait"
@@ -381,6 +397,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,9 +421,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.18"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "shlex",
 ]
@@ -422,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.35"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -432,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.35"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -537,6 +564,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +579,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "drop-stream"
@@ -590,6 +629,15 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -698,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -727,9 +775,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -999,15 +1047,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
@@ -1046,18 +1094,18 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "minreq"
-version = "2.13.3"
+version = "2.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567496f13503d6cae8c9f961f34536850275f396307d7a6b981eef1464032f53"
+checksum = "f0d2aaba477837b46ec1289588180fabfccf0c3b1d1a0c6b1866240cd6cd5ce9"
 dependencies = [
  "log",
  "serde",
@@ -1096,6 +1144,12 @@ dependencies = [
  "sha2",
  "subtle",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-conv"
@@ -1191,6 +1245,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -1303,7 +1387,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1339,12 +1423,14 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 name = "rpc"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "bdk_bitcoind_rpc",
  "bdk_wallet",
  "clap",
  "drop-stream",
  "futures",
  "musig2",
+ "predicates",
  "prost",
  "rand",
  "serde",
@@ -1523,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
@@ -1580,6 +1666,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1670,15 +1762,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "pin-project-lite",
  "tokio",
 ]
@@ -1817,6 +1909,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -30,7 +30,6 @@ anyhow = "1.0.98"
 assert_cmd = "2.0.17"
 const_format = "0.2.34"
 predicates = "3.1.3"
-tokio-util = { version = "0.7.15", features = ["rt"] }
 
 [lints.clippy]
 pedantic = "warn"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -7,7 +7,7 @@ default-run = "musig-cli"
 [dependencies]
 bdk_bitcoind_rpc = "0.18.0"
 bdk_wallet = "1.2.0"
-clap = { version = "4.5.37", features = ["derive"] }
+clap = { version = "4.5.38", features = ["derive"] }
 drop-stream = "0.3.2"
 futures = "0.3.31"
 musig2 = { version = "0.2.4", features = ["rand"] }
@@ -26,6 +26,7 @@ tonic-build = "0.13.0"
 
 [dev-dependencies]
 rpc = { path = ".", features = ["unimock"] }
+anyhow = "1.0.98"
 assert_cmd = "2.0.17"
 const_format = "0.2.34"
 predicates = "3.1.3"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -16,15 +16,18 @@ rand = "0.8.5"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_with = { version = "3.12.0", features = ["hex"] }
 thiserror = "2.0.12"
-tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.45.0", features = ["macros", "rt-multi-thread", "time"] }
 tokio-stream = "0.1.17"
-tonic = "0.13.0"
+tonic = "0.13.1"
+unimock = { version = "0.6.7", optional = true }
 
 [build-dependencies]
 tonic-build = "0.13.0"
 
 [dev-dependencies]
+rpc = { path = ".", features = ["unimock"] }
 assert_cmd = "2.0.17"
+const_format = "0.2.34"
 predicates = "3.1.3"
 tokio-util = { version = "0.7.15", features = ["rt"] }
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -7,7 +7,7 @@ default-run = "musig-cli"
 [dependencies]
 bdk_bitcoind_rpc = "0.18.0"
 bdk_wallet = "1.2.0"
-clap = { version = "4.5.35", features = ["derive"] }
+clap = { version = "4.5.37", features = ["derive"] }
 drop-stream = "0.3.2"
 futures = "0.3.31"
 musig2 = { version = "0.2.4", features = ["rand"] }
@@ -16,7 +16,7 @@ rand = "0.8.5"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_with = { version = "3.12.0", features = ["hex"] }
 thiserror = "2.0.12"
-tokio = { version = "1.44.1", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread", "time"] }
 tokio-stream = "0.1.17"
 tonic = "0.13.0"
 
@@ -24,7 +24,9 @@ tonic = "0.13.0"
 tonic-build = "0.13.0"
 
 [dev-dependencies]
-tokio-util = { version = "0.7.14", features = ["rt"] }
+assert_cmd = "2.0.17"
+predicates = "3.1.3"
+tokio-util = { version = "0.7.15", features = ["rt"] }
 
 [lints.clippy]
 pedantic = "warn"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -13,6 +13,8 @@ futures = "0.3.31"
 musig2 = { version = "0.2.4", features = ["rand"] }
 prost = "0.13.5"
 rand = "0.8.5"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_with = { version = "3.12.0", features = ["hex"] }
 thiserror = "2.0.12"
 tokio = { version = "1.44.1", features = ["macros", "rt-multi-thread", "time"] }
 tokio-stream = "0.1.17"

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -70,3 +70,31 @@ mvn install exec:java
 ```sh
 mvn exec:java -Pwallet
 ```
+
+### Integration tests using Nigiri
+
+Some of the integration tests require [Nigiri](https://github.com/vulpemventures/nigiri) to run, which is a command-line
+interface managing a selection of `docker-compose` containers providing a local regtest network. A custom datadir
+relative to the root of the `rpc` crate is assumed, with currently only the `bitcoin` component being used by the tests,
+though later `electrs` will be likely also be used to test and develop an Electrum wallet backend.
+
+To start Nigiri with the project-local datadir, run:
+
+```sh
+nigiri --datadir "$PWD/.nigiri" start
+```
+
+This will also fetch and install the containers and their configuration in `$PWD/.nigiri` if run for the first time. The
+Rust integration and unit tests may be run by:
+
+```sh
+cargo test
+```
+
+as usual, which will automatically start Nigiri (with the `--ci` flag to exclude Esplora) if it isn't running already.
+
+It continues to run after the tests finish, so to stop Nigiri, subsequently run:
+
+```sh
+nigiri --datadir "$PWD/.nigiri" stop
+```

--- a/rpc/build.rs
+++ b/rpc/build.rs
@@ -1,7 +1,70 @@
+use std::borrow::Cow;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure().compile_protos(
-        &["src/main/proto/rpc.proto", "src/main/proto/wallet.proto"],
-        &["src/main/proto"],
-    )?;
+    tonic_build::configure()
+        .serde_serialized_types(&["WalletBalanceResponse", "NewAddressResponse", "ListUnspentResponse"])
+        .serde_serialized_type("TransactionOutput", &[
+            rev_hex("txId"), hex("scriptPubKey")
+        ])
+        .serde_serialized_type("ConfEvent", &[
+            opt_hex("rawTx"), enum_field("confidenceType", "ConfidenceType")
+        ])
+        .serde_serialized_type("ConfirmationBlockTime", &[
+            rev_hex("blockHash")
+        ])
+        .serde_serialized_enum("ConfidenceType")
+        .compile_protos(
+            &["src/main/proto/rpc.proto", "src/main/proto/wallet.proto"],
+            &["src/main/proto"],
+        )?;
     Ok(())
+}
+
+type CustomField<'a> = (&'a str, Cow<'static, str>);
+
+const fn hex(field: &str) -> CustomField {
+    (field, Cow::Borrowed("#[serde_as(as = \"::serde_with::hex::Hex\")]"))
+}
+
+const fn rev_hex(field: &str) -> CustomField {
+    (field, Cow::Borrowed("#[serde_as(as = \"crate::pb::convert::hex::ByteReversedHex\")]"))
+}
+
+const fn opt_hex(field: &str) -> CustomField {
+    (field, Cow::Borrowed("#[serde_as(as = \"::core::option::Option<::serde_with::hex::Hex>\")]"))
+}
+
+fn enum_field<'a>(field: &'a str, type_name: &'_ str) -> CustomField<'a> {
+    (field, Cow::Owned(format!("#[serde_as(as = \"::serde_with::TryFromInto<{type_name}>\")]")))
+}
+
+trait BuilderEx {
+    fn serde_serialized_enum(self, path: &str) -> Self;
+
+    fn serde_serialized_type(self, path: &str, custom_fields: &[CustomField]) -> Self;
+
+    fn serde_serialized_types(mut self, paths: &[&str]) -> Self where Self: Sized {
+        for &path in paths {
+            self = self.serde_serialized_type(path, &[]);
+        }
+        self
+    }
+}
+
+impl BuilderEx for tonic_build::Builder {
+    fn serde_serialized_enum(self, path: &str) -> Self {
+        self.enum_attribute(path, "#[derive(::serde::Serialize)]")
+            .enum_attribute(path, "#[serde(rename_all = \"SCREAMING_SNAKE_CASE\")]")
+    }
+
+    fn serde_serialized_type(mut self, path: &str, custom_fields: &[CustomField]) -> Self {
+        self = self
+            .type_attribute(path, "#[::serde_with::serde_as]")
+            .type_attribute(path, "#[derive(::serde::Serialize)]")
+            .type_attribute(path, "#[serde(rename_all = \"camelCase\")]");
+        for (field, attribute) in custom_fields {
+            self = self.field_attribute(format!("{path}.{field}"), attribute);
+        }
+        self
+    }
 }

--- a/rpc/clippy.toml
+++ b/rpc/clippy.toml
@@ -1,0 +1,3 @@
+# For Rust 1.87 until fixed: Prevent perf warnings due to `tonic::Result::Err`-variant >=176 bytes.
+# See: https://github.com/hyperium/tonic/issues/2253
+large-error-threshold = 256

--- a/rpc/pom.xml
+++ b/rpc/pom.xml
@@ -84,7 +84,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <release>22</release>
+                    <release>21</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/rpc/src/bin/musig-cli.rs
+++ b/rpc/src/bin/musig-cli.rs
@@ -1,4 +1,5 @@
 use bdk_wallet::bitcoin::hashes::{Hash as _, sha256d};
+use bdk_wallet::serde_json;
 use clap::{Parser, Subcommand};
 use futures::StreamExt as _;
 use rpc::pb::walletrpc::{ConfRequest, ListUnspentRequest, NewAddressRequest, WalletBalanceRequest};
@@ -39,17 +40,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::WalletBalance => {
             let response = client.wallet_balance(Request::new(WalletBalanceRequest {})).await?;
             drop(client);
-            println!("{response:#?}");
+            println!("{}", serde_json::to_string_pretty(&response.into_inner())?);
         }
         Commands::NewAddress => {
             let response = client.new_address(Request::new(NewAddressRequest {})).await?;
             drop(client);
-            println!("{response:#?}");
+            println!("{}", serde_json::to_string_pretty(&response.into_inner())?);
         }
         Commands::ListUnspent => {
             let response = client.list_unspent(Request::new(ListUnspentRequest {})).await?;
             drop(client);
-            println!("{response:?}");
+            println!("{}", serde_json::to_string_pretty(&response.into_inner())?);
         }
         Commands::NotifyConfidence { tx_id } => {
             let tx_id = tx_id.parse::<sha256d::Hash>()?.as_byte_array().to_vec();
@@ -57,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             drop(client);
             let mut stream = response.into_inner();
             while let Some(event_result) = stream.next().await {
-                println!("{:?}", event_result?);
+                println!("{}", serde_json::to_string_pretty(&event_result?)?);
             }
         }
     }

--- a/rpc/src/bin/musigd.rs
+++ b/rpc/src/bin/musigd.rs
@@ -1,11 +1,22 @@
-use rpc::wallet::WalletServiceImpl;
+use clap::Parser;
 use rpc::server::{MusigImpl, MusigServer, WalletImpl, WalletServer};
+use rpc::wallet::WalletServiceImpl;
 use std::sync::Arc;
 use tonic::transport::Server;
 
+#[derive(Debug, Parser)]
+#[command(version, about, long_about = None)]
+#[expect(clippy::doc_markdown, reason = "doc comments are used verbatim by Clap and not intended to be markdown")]
+struct Cli {
+    /// The port of the MuSig daemon
+    #[arg(short, long, default_value_t = 50051)]
+    port: u16,
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let addr = "127.0.0.1:50051".parse()?;
+    let cli: Cli = Cli::parse();
+    let addr = format!("127.0.0.1:{}", cli.port).parse()?;
     let musig = MusigImpl::default();
     let wallet = WalletImpl { wallet_service: Arc::new(WalletServiceImpl::new()) };
     wallet.wallet_service.clone().spawn_connection();

--- a/rpc/src/main/proto/rpc.proto
+++ b/rpc/src/main/proto/rpc.proto
@@ -12,11 +12,14 @@ service Musig {
 
   rpc PublishDepositTx (PublishDepositTxRequest) returns (stream TxConfirmationStatus);
 
+  rpc SubscribeTxConfirmationStatus (SubscribeTxConfirmationStatusRequest) returns (stream TxConfirmationStatus);
+
   rpc SignSwapTx (SwapTxSignatureRequest) returns (SwapTxSignatureResponse);
 
   rpc CloseTrade (CloseTradeRequest) returns (CloseTradeResponse);
 }
 
+// TODO: Same as 'trade.TradeRole' from Bisq2 protos (minus 'UNSPECIFIED' variant, which should probably be added):
 enum Role {
   SELLER_AS_MAKER = 0;
   SELLER_AS_TAKER = 1;
@@ -87,6 +90,11 @@ message DepositPsbt {
 }
 
 message PublishDepositTxRequest {
+  string tradeId = 1;
+  DepositPsbt depositPsbt = 2;
+}
+
+message SubscribeTxConfirmationStatusRequest {
   string tradeId = 1;
   DepositPsbt depositPsbt = 2;
 }

--- a/rpc/src/pb/convert.rs
+++ b/rpc/src/pb/convert.rs
@@ -17,6 +17,23 @@ use crate::protocol::{ExchangedNonces, ExchangedSigs, ProtocolErrorKind, Redirec
 use crate::storage::{ByRef, ByVal};
 use crate::wallet::TxConfidence;
 
+pub(crate) mod hex {
+    use serde_with::SerializeAs;
+    use serde_with::formats::Lowercase;
+    use serde_with::hex::Hex;
+    use serde::Serializer;
+
+    pub struct ByteReversedHex;
+
+    impl<T: AsRef<[u8]>> SerializeAs<T> for ByteReversedHex {
+        fn serialize_as<S: Serializer>(source: &T, serializer: S) -> Result<S::Ok, S::Error> {
+            let mut source = source.as_ref().to_owned();
+            source.reverse();
+            Hex::<Lowercase>::serialize_as(&source, serializer)
+        }
+    }
+}
+
 pub trait TryProtoInto<T> {
     /// # Errors
     /// Will return `Err` if conversion from proto fails

--- a/rpc/src/wallet.rs
+++ b/rpc/src/wallet.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "unimock", expect(clippy::ignored_unit_patterns, reason = "macro-generated code"))]
+
 use bdk_bitcoind_rpc::Emitter;
 use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client, RpcApi as _};
 use bdk_wallet::{AddressInfo, Balance, KeychainKind, LocalOutput, Wallet};
@@ -21,6 +23,7 @@ const EXTERNAL_DESCRIPTOR: &str = "tr(tprv8ZgxMBicQKsPdrjwWCyXqqJ4YqcyG4DmKtjjsR
 const INTERNAL_DESCRIPTOR: &str = "tr(tprv8ZgxMBicQKsPdrjwWCyXqqJ4YqcyG4DmKtjjsRt29v1PtD3r3PuFJAj\
     WytzcvSTKnZAGAkPSmnrdnuHWxCAwy3i1iPhrtKAfXRH7dVCNGp6/86'/1'/0'/1/*)#e3rjrmea";
 
+#[cfg_attr(feature = "unimock", unimock::unimock(api = WalletServiceMock))]
 #[tonic::async_trait]
 pub trait WalletService {
     /// # Errors

--- a/rpc/tests/cli.rs
+++ b/rpc/tests/cli.rs
@@ -1,16 +1,32 @@
 use assert_cmd::Command;
 use assert_cmd::assert::Assert;
+use bdk_wallet::{KeychainKind, LocalOutput};
+use bdk_wallet::bitcoin::{OutPoint, Transaction};
+use bdk_wallet::bitcoin::consensus::Decodable as _;
+use bdk_wallet::bitcoin::hex::test_hex_unwrap as hex;
+use bdk_wallet::chain::{ChainPosition, ConfirmationBlockTime};
+use const_format::str_replace;
 use rpc::server::{WalletImpl, WalletServer};
-use rpc::wallet::WalletServiceImpl;
+use rpc::wallet::{TxConfidence, WalletService, WalletServiceImpl, WalletServiceMock, WalletTx};
 use predicates::str;
 use std::sync::Arc;
 use std::time::Duration;
+use futures::stream::{self, BoxStream, StreamExt as _};
 use tokio::task::{self, JoinHandle};
 use tokio_util::task::AbortOnDropHandle;
 use tonic::transport::{self, Server};
 use tonic::transport::server::TcpIncoming;
+use unimock::{MockFn as _, Unimock, matching};
 
-const CLI_TIMEOUT: Duration = Duration::from_millis(100);
+const CLI_TIMEOUT: Duration = Duration::from_millis(200);
+
+//noinspection SpellCheckingInspection
+const MOCK_TX: &str = "02000000000101fb8ab4c1fb7ea3fe11a35d24853653df8823b7552cb561e5626bf4b709bbf9\
+    f70000000000fdffffff0200f90295000000002251206523edfb7a73d0d1e1b38ec0068503b46557bc8368e4e4d3057\
+    5c9f524e9a8748ef202950000000022512025a006cf9eb838697404da9568728e678e4fb704007d8f154b300fbdba3c\
+    9fb602473044022042821bee4e1afa02ce2ec5a931a964a3110c18987dae0c176f4ef83656ff149f0220730cc1917a8\
+    277d92ad9af155730630ac5482759300bbdf0d5083407f8dea3e401210226e4d88cd0ea0cd405b8f03e4226291e094c\
+    1e8fe83a3536d438146a56c421f000000000";
 
 const EXPECTED_WALLET_BALANCE_RESPONSE: &str = r#"{
   "immature": 0,
@@ -30,16 +46,39 @@ const EXPECTED_NEW_ADDRESS_RESPONSE_2: &str = r#"{
 }
 "#;
 const EXPECTED_LIST_UNSPENT_RESPONSE: &str = r#"{
-  "utxos": []
+  "utxos": [
+    {
+      "txId": "37b560334094515cfdaa0146bfd4ce19e940064c505082031858b0aba3218990",
+      "vout": 0,
+      "scriptPubKey": "51206523edfb7a73d0d1e1b38ec0068503b46557bc8368e4e4d30575c9f524e9a874",
+      "value": 2500000000
+    }
+  ]
 }
 "#;
-const EXPECTED_NOTIFY_CONFIDENCE_RESPONSE: &str = r#"{
+const EXPECTED_NOTIFY_CONFIDENCE_RESPONSE: &str = str_replace!(r#"{
   "rawTx": null,
   "confidenceType": "MISSING",
   "numConfirmations": 0,
   "confirmationBlockTime": null
 }
-"#;
+{
+  "rawTx": "$MOCK_TX",
+  "confidenceType": "UNCONFIRMED",
+  "numConfirmations": 0,
+  "confirmationBlockTime": null
+}
+{
+  "rawTx": "$MOCK_TX",
+  "confidenceType": "CONFIRMED",
+  "numConfirmations": 1,
+  "confirmationBlockTime": {
+    "blockHash": "01b623501ea6b83b14035d8b965eaa8c78eeeaf773f60b35228ae4929e7dad56",
+    "blockHeight": 104,
+    "confirmationTime": 1743580321
+  }
+}
+"#, "$MOCK_TX", MOCK_TX);
 
 #[test]
 fn test_cli_usage() {
@@ -60,7 +99,7 @@ fn test_cli_no_connection() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_cli_wallet_balance() {
     let mut port = 50052;
-    let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port));
+    let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port, WalletServiceImpl::new()));
 
     task::spawn_blocking(move || assert_cli_with_port(port, ["wallet-balance"]))
         .await.unwrap()
@@ -72,7 +111,7 @@ async fn test_cli_wallet_balance() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_cli_new_address() {
     let mut port = 50052;
-    let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port));
+    let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port, WalletServiceImpl::new()));
 
     task::spawn_blocking(move || assert_cli_with_port(port, ["new-address"]))
         .await.unwrap()
@@ -89,8 +128,12 @@ async fn test_cli_new_address() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_cli_list_unspent() {
+    let clause = WalletServiceMock::list_unspent
+        .some_call(matching!()).returns(vec![mock_utxo()]);
+    let mock_wallet_service = Unimock::new(clause).no_verify_in_drop();
+
     let mut port = 50052;
-    let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port));
+    let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port, mock_wallet_service));
 
     task::spawn_blocking(move || assert_cli_with_port(port, ["list-unspent"]))
         .await.unwrap()
@@ -102,8 +145,13 @@ async fn test_cli_list_unspent() {
 //noinspection SpellCheckingInspection
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_cli_notify_confidence() {
+    let clause = WalletServiceMock::get_tx_confidence_stream
+        .some_call(matching!((arg) if *arg == mock_tx().compute_txid()))
+        .answers(&|_, _| mock_confidence_stream());
+    let mock_wallet_service = Unimock::new(clause).no_verify_in_drop();
+
     let mut port = 50052;
-    let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port));
+    let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port, mock_wallet_service));
 
     task::spawn_blocking(move || assert_cli_with_port(port, ["notify-confidence",
         "37b560334094515cfdaa0146bfd4ce19e940064c505082031858b0aba3218990"]))
@@ -111,6 +159,58 @@ async fn test_cli_notify_confidence() {
         .interrupted()
         .stdout(EXPECTED_NOTIFY_CONFIDENCE_RESPONSE)
         .stderr(str::is_empty());
+}
+
+fn mock_tx() -> Transaction {
+    let raw_tx = hex!(MOCK_TX);
+    Transaction::consensus_decode(&mut raw_tx.as_slice()).unwrap()
+}
+
+//noinspection SpellCheckingInspection
+fn mock_chain_position() -> ChainPosition<ConfirmationBlockTime> {
+    ChainPosition::Confirmed {
+        anchor: ConfirmationBlockTime {
+            block_id: (104, "01b623501ea6b83b14035d8b965eaa8c78eeeaf773f60b35228ae4929e7dad56"
+                .parse().unwrap()).into(),
+            confirmation_time: 1_743_580_321,
+        },
+        transitively: None,
+    }
+}
+
+fn mock_utxo() -> LocalOutput {
+    let tx = mock_tx();
+    LocalOutput {
+        outpoint: OutPoint::new(tx.compute_txid(), 0),
+        txout: tx.output[0].clone(),
+        keychain: KeychainKind::External,
+        is_spent: false,
+        derivation_index: 1,
+        chain_position: mock_chain_position(),
+    }
+}
+
+fn mock_confidence_stream() -> BoxStream<'static, Option<TxConfidence>> {
+    let tx = Arc::new(mock_tx());
+    let txid = tx.compute_txid();
+    let event1 = None;
+    let event2 = Some(TxConfidence {
+        wallet_tx: WalletTx {
+            txid,
+            tx: tx.clone(),
+            chain_position: ChainPosition::Unconfirmed { last_seen: Some(0) },
+        },
+        num_confirmations: 0,
+    });
+    let event3 = Some(TxConfidence {
+        wallet_tx: WalletTx {
+            txid,
+            tx,
+            chain_position: mock_chain_position(),
+        },
+        num_confirmations: 1,
+    });
+    stream::iter([event1, event2, event3]).chain(stream::pending()).boxed()
 }
 
 fn assert_cli<'a>(args: impl IntoIterator<Item=&'a str>) -> Assert {
@@ -129,8 +229,9 @@ fn assert_cli_with_port<'a>(port: u16, args: impl IntoIterator<Item=&'a str>) ->
     assert_cli(args)
 }
 
-fn spawn_wallet_grpc_service(port: &mut u16) -> JoinHandle<Result<(), transport::Error>> {
-    let wallet = WalletImpl { wallet_service: Arc::new(WalletServiceImpl::new()) };
+fn spawn_wallet_grpc_service(port: &mut u16, wallet_service: impl WalletService + Send + Sync + 'static)
+                             -> JoinHandle<Result<(), transport::Error>> {
+    let wallet = WalletImpl { wallet_service: Arc::new(wallet_service) };
     let incoming = loop {
         let addr = format!("127.0.0.1:{port}").parse().unwrap();
         match TcpIncoming::bind(addr) {

--- a/rpc/tests/cli.rs
+++ b/rpc/tests/cli.rs
@@ -1,44 +1,60 @@
+use assert_cmd::Command;
+use assert_cmd::assert::Assert;
 use rpc::server::{WalletImpl, WalletServer};
 use rpc::wallet::WalletServiceImpl;
-use std::process::{Command, Output};
+use predicates::str;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::task::{self, JoinHandle};
 use tokio_util::task::AbortOnDropHandle;
 use tonic::transport::{self, Server};
 use tonic::transport::server::TcpIncoming;
 
-const EXPECTED_WALLET_BALANCE_RESPONSE: &[u8] = br#"{
+const CLI_TIMEOUT: Duration = Duration::from_millis(100);
+
+const EXPECTED_WALLET_BALANCE_RESPONSE: &str = r#"{
   "immature": 0,
   "trustedPending": 0,
   "untrustedPending": 0,
   "confirmed": 0
 }
 "#;
-const EXPECTED_NEW_ADDRESS_RESPONSE_1: &[u8] = br#"{
+const EXPECTED_NEW_ADDRESS_RESPONSE_1: &str = r#"{
   "address": "bcrt1pkar3gerekw8f9gef9vn9xz0qypytgacp9wa5saelpksdgct33qdqan7c89",
   "derivationPath": "m/86'/1'/0'/0/0"
 }
 "#;
-const EXPECTED_NEW_ADDRESS_RESPONSE_2: &[u8] = br#"{
+const EXPECTED_NEW_ADDRESS_RESPONSE_2: &str = r#"{
   "address": "bcrt1pv537m7m6w0gdrcdn3mqqdpgrk3j400yrdrjwf5c9whyl2f8f4p6q9dn3l9",
   "derivationPath": "m/86'/1'/0'/0/1"
+}
+"#;
+const EXPECTED_LIST_UNSPENT_RESPONSE: &str = r#"{
+  "utxos": []
+}
+"#;
+const EXPECTED_NOTIFY_CONFIDENCE_RESPONSE: &str = r#"{
+  "rawTx": null,
+  "confidenceType": "MISSING",
+  "numConfirmations": 0,
+  "confirmationBlockTime": null
 }
 "#;
 
 #[test]
 fn test_cli_usage() {
-    let output = exec_cli([]);
-    assert_eq!(output.status.code(), Some(2));
-    assert!(output.stdout.is_empty());
-    assert!(output.stderr.starts_with(b"Usage:"));
+    assert_cli([])
+        .code(2)
+        .stdout(str::is_empty())
+        .stderr(str::starts_with("Usage:"));
 }
 
 #[test]
 fn test_cli_no_connection() {
-    let output = exec_cli_with_port(50050, ["wallet-balance"]);
-    assert_eq!(output.status.code(), Some(1));
-    assert!(output.stdout.is_empty());
-    assert!(output.stderr.contains_subslice(b"ConnectError"));
+    assert_cli_with_port(50050, ["wallet-balance"])
+        .code(1)
+        .stdout(str::is_empty())
+        .stderr(str::contains("ConnectError"));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -46,11 +62,11 @@ async fn test_cli_wallet_balance() {
     let mut port = 50052;
     let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port));
 
-    let output = task::spawn_blocking(move || exec_cli_with_port(port, ["wallet-balance"]))
-        .await.unwrap();
-    assert!(output.status.success());
-    assert_eq!(output.stdout, EXPECTED_WALLET_BALANCE_RESPONSE);
-    assert!(output.stderr.is_empty());
+    task::spawn_blocking(move || assert_cli_with_port(port, ["wallet-balance"]))
+        .await.unwrap()
+        .success()
+        .stdout(EXPECTED_WALLET_BALANCE_RESPONSE)
+        .stderr(str::is_empty());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -58,32 +74,59 @@ async fn test_cli_new_address() {
     let mut port = 50052;
     let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port));
 
-    let output = task::spawn_blocking(move || exec_cli_with_port(port, ["new-address"]))
-        .await.unwrap();
-    assert!(output.status.success());
-    assert_eq!(output.stdout, EXPECTED_NEW_ADDRESS_RESPONSE_1);
-    assert!(output.stderr.is_empty());
+    task::spawn_blocking(move || assert_cli_with_port(port, ["new-address"]))
+        .await.unwrap()
+        .success()
+        .stdout(EXPECTED_NEW_ADDRESS_RESPONSE_1)
+        .stderr(str::is_empty());
 
-    let output = task::spawn_blocking(move || exec_cli_with_port(port, ["new-address"]))
-        .await.unwrap();
-    assert!(output.status.success());
-    assert_eq!(output.stdout, EXPECTED_NEW_ADDRESS_RESPONSE_2);
-    assert!(output.stderr.is_empty());
+    task::spawn_blocking(move || assert_cli_with_port(port, ["new-address"]))
+        .await.unwrap()
+        .success()
+        .stdout(EXPECTED_NEW_ADDRESS_RESPONSE_2)
+        .stderr(str::is_empty());
 }
 
-fn exec_cli<'a>(args: impl IntoIterator<Item=&'a str>) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_musig-cli"))
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_cli_list_unspent() {
+    let mut port = 50052;
+    let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port));
+
+    task::spawn_blocking(move || assert_cli_with_port(port, ["list-unspent"]))
+        .await.unwrap()
+        .success()
+        .stdout(EXPECTED_LIST_UNSPENT_RESPONSE)
+        .stderr(str::is_empty());
+}
+
+//noinspection SpellCheckingInspection
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_cli_notify_confidence() {
+    let mut port = 50052;
+    let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port));
+
+    task::spawn_blocking(move || assert_cli_with_port(port, ["notify-confidence",
+        "37b560334094515cfdaa0146bfd4ce19e940064c505082031858b0aba3218990"]))
+        .await.unwrap()
+        .interrupted()
+        .stdout(EXPECTED_NOTIFY_CONFIDENCE_RESPONSE)
+        .stderr(str::is_empty());
+}
+
+fn assert_cli<'a>(args: impl IntoIterator<Item=&'a str>) -> Assert {
+    Command::cargo_bin("musig-cli").unwrap()
         .args(args)
-        .output().unwrap()
+        .timeout(CLI_TIMEOUT)
+        .assert()
 }
 
-fn exec_cli_with_port<'a>(port: u16, args: impl IntoIterator<Item=&'a str>) -> Output {
+fn assert_cli_with_port<'a>(port: u16, args: impl IntoIterator<Item=&'a str>) -> Assert {
     let port = port.to_string();
     #[expect(clippy::map_identity, reason = "change-of-lifetime false positive; see \
         https://github.com/rust-lang/rust-clippy/issues/9280")]
     let args = ["--port", &port].into_iter()
         .chain(args.into_iter().map(|s| s));
-    exec_cli(args)
+    assert_cli(args)
 }
 
 fn spawn_wallet_grpc_service(port: &mut u16) -> JoinHandle<Result<(), transport::Error>> {
@@ -101,14 +144,4 @@ fn spawn_wallet_grpc_service(port: &mut u16) -> JoinHandle<Result<(), transport:
             .serve_with_incoming(incoming)
             .await
     })
-}
-
-trait Searchable<T> {
-    fn contains_subslice(&self, subslice: &[T]) -> bool;
-}
-
-impl<T: PartialEq> Searchable<T> for [T] {
-    fn contains_subslice(&self, subslice: &[T]) -> bool {
-        self.windows(subslice.len()).any(|s| subslice.eq(s))
-    }
 }

--- a/rpc/tests/cli.rs
+++ b/rpc/tests/cli.rs
@@ -7,6 +7,24 @@ use tokio_util::task::AbortOnDropHandle;
 use tonic::transport::{self, Server};
 use tonic::transport::server::TcpIncoming;
 
+const EXPECTED_WALLET_BALANCE_RESPONSE: &[u8] = br#"{
+  "immature": 0,
+  "trustedPending": 0,
+  "untrustedPending": 0,
+  "confirmed": 0
+}
+"#;
+const EXPECTED_NEW_ADDRESS_RESPONSE_1: &[u8] = br#"{
+  "address": "bcrt1pkar3gerekw8f9gef9vn9xz0qypytgacp9wa5saelpksdgct33qdqan7c89",
+  "derivationPath": "m/86'/1'/0'/0/0"
+}
+"#;
+const EXPECTED_NEW_ADDRESS_RESPONSE_2: &[u8] = br#"{
+  "address": "bcrt1pv537m7m6w0gdrcdn3mqqdpgrk3j400yrdrjwf5c9whyl2f8f4p6q9dn3l9",
+  "derivationPath": "m/86'/1'/0'/0/1"
+}
+"#;
+
 #[test]
 fn test_cli_usage() {
     let output = exec_cli([]);
@@ -31,8 +49,7 @@ async fn test_cli_wallet_balance() {
     let output = task::spawn_blocking(move || exec_cli_with_port(port, ["wallet-balance"]))
         .await.unwrap();
     assert!(output.status.success());
-    assert!(output.stdout.contains_subslice(b"WalletBalanceResponse"));
-    assert!(output.stdout.contains_subslice(b"confirmed: 0"));
+    assert_eq!(output.stdout, EXPECTED_WALLET_BALANCE_RESPONSE);
     assert!(output.stderr.is_empty());
 }
 
@@ -44,17 +61,13 @@ async fn test_cli_new_address() {
     let output = task::spawn_blocking(move || exec_cli_with_port(port, ["new-address"]))
         .await.unwrap();
     assert!(output.status.success());
-    assert!(output.stdout.contains_subslice(b"NewAddressResponse"));
-    assert!(output.stdout.contains_subslice(b"address: \"bcrt1pkar3gerekw8f9gef9vn9xz0qypytgacp9wa5saelpksdgct33qdqan7c89\""));
-    assert!(output.stdout.contains_subslice(b"derivation_path: \"m/86'/1'/0'/0/0\""));
+    assert_eq!(output.stdout, EXPECTED_NEW_ADDRESS_RESPONSE_1);
     assert!(output.stderr.is_empty());
 
     let output = task::spawn_blocking(move || exec_cli_with_port(port, ["new-address"]))
         .await.unwrap();
     assert!(output.status.success());
-    assert!(output.stdout.contains_subslice(b"NewAddressResponse"));
-    assert!(output.stdout.contains_subslice(b"address: \"bcrt1pv537m7m6w0gdrcdn3mqqdpgrk3j400yrdrjwf5c9whyl2f8f4p6q9dn3l9\""));
-    assert!(output.stdout.contains_subslice(b"derivation_path: \"m/86'/1'/0'/0/1\""));
+    assert_eq!(output.stdout, EXPECTED_NEW_ADDRESS_RESPONSE_2);
     assert!(output.stderr.is_empty());
 }
 

--- a/rpc/tests/cli.rs
+++ b/rpc/tests/cli.rs
@@ -13,7 +13,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use futures::stream::{self, BoxStream, StreamExt as _};
 use tokio::task::{self, JoinHandle};
-use tokio_util::task::AbortOnDropHandle;
 use tonic::transport::{self, Server};
 use tonic::transport::server::TcpIncoming;
 use unimock::{MockFn as _, Unimock, matching};
@@ -99,7 +98,7 @@ fn test_cli_no_connection() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_cli_wallet_balance() {
     let mut port = 50052;
-    let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port, WalletServiceImpl::new()));
+    spawn_wallet_grpc_service(&mut port, WalletServiceImpl::new());
 
     task::spawn_blocking(move || assert_cli_with_port(port, ["wallet-balance"]))
         .await.unwrap()
@@ -111,7 +110,7 @@ async fn test_cli_wallet_balance() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_cli_new_address() {
     let mut port = 50052;
-    let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port, WalletServiceImpl::new()));
+    spawn_wallet_grpc_service(&mut port, WalletServiceImpl::new());
 
     task::spawn_blocking(move || assert_cli_with_port(port, ["new-address"]))
         .await.unwrap()
@@ -133,7 +132,7 @@ async fn test_cli_list_unspent() {
     let mock_wallet_service = Unimock::new(clause).no_verify_in_drop();
 
     let mut port = 50052;
-    let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port, mock_wallet_service));
+    spawn_wallet_grpc_service(&mut port, mock_wallet_service);
 
     task::spawn_blocking(move || assert_cli_with_port(port, ["list-unspent"]))
         .await.unwrap()
@@ -151,7 +150,7 @@ async fn test_cli_notify_confidence() {
     let mock_wallet_service = Unimock::new(clause).no_verify_in_drop();
 
     let mut port = 50052;
-    let _guard = AbortOnDropHandle::new(spawn_wallet_grpc_service(&mut port, mock_wallet_service));
+    spawn_wallet_grpc_service(&mut port, mock_wallet_service);
 
     task::spawn_blocking(move || assert_cli_with_port(port, ["notify-confidence",
         "37b560334094515cfdaa0146bfd4ce19e940064c505082031858b0aba3218990"]))

--- a/rpc/tests/wallet_service.rs
+++ b/rpc/tests/wallet_service.rs
@@ -1,0 +1,152 @@
+use anyhow::{bail, Result};
+use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client, RpcApi as _};
+use bdk_bitcoind_rpc::bitcoincore_rpc::bitcoincore_rpc_json::EstimateMode;
+use bdk_wallet::{Balance, serde_json};
+use bdk_wallet::bitcoin::{Address, Amount, BlockHash, Txid};
+use futures::StreamExt as _;
+use rpc::wallet::{TxConfidence, WalletService, WalletServiceImpl};
+use std::collections::HashMap;
+use std::fs;
+use std::process::Command;
+use std::sync::Arc;
+use serde::Deserialize;
+use tokio::sync::{OnceCell, Semaphore, SemaphorePermit};
+use tokio::time::{self, Duration};
+use tokio::task;
+use tokio_util::task::AbortOnDropHandle;
+
+const BITCOIND_RPC_URL: &str = "http://localhost:18443";
+const BITCOIND_POLLING_PERIOD: Duration = Duration::from_millis(100);
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_wallet_service_mine_single_tx() {
+    let (wallet_service, _guard, _permit) = start_wallet_service_with_nigiri_permit().await;
+    let balance1 = wallet_service.balance();
+
+    // Send 0.01 BTC from bitcoind to a fresh wallet address and wait for wallet to sync.
+    let addr = wallet_service.reveal_next_address();
+    let amount = Amount::from_sat(1_000_000);
+    let txid = send_to_address(&addr.address, Amount::from_sat(1_000_000));
+    time::sleep(BITCOIND_POLLING_PERIOD * 2).await;
+
+    // Open up a tx confidence stream on the (unconfirmed) paying tx.
+    let mut stream = wallet_service.get_tx_confidence_stream(txid);
+    assert!(matches!(stream.next().await, Some(Some(TxConfidence { num_confirmations: 0, .. }))));
+
+    let balance2 = wallet_service.balance();
+    assert_eq!(balance2.total(), balance1.total() + amount);
+    assert!(balance2.untrusted_pending >= amount);
+
+    // Mine a block and wait for wallet to sync.
+    mine_single();
+    time::sleep(BITCOIND_POLLING_PERIOD * 2).await;
+
+    let balance3 = wallet_service.balance();
+    assert_eq!(balance3.total(), balance2.total());
+    assert_eq!(balance3.trusted_pending, Amount::ZERO);
+    assert_eq!(balance3.untrusted_pending, Amount::ZERO);
+
+    // The tx should now be confirmed.
+    assert!(matches!(stream.next().await, Some(Some(TxConfidence { num_confirmations: 1, .. }))));
+}
+
+fn send_to_address(address: &Address, amount: Amount) -> Txid {
+    Result::<_>::unwrap(task::block_in_place(|| {
+        let client = Client::new(BITCOIND_RPC_URL, nigiri_rpc_auth())?;
+        Ok(client.send_to_address(address, amount, None, None, None, Some(true),
+            None, Some(EstimateMode::Economical))?)
+    }))
+}
+
+fn mine_single() -> BlockHash {
+    mine(1, None)[0]
+}
+
+fn mine(block_num: u64, to_address: Option<&Address>) -> Vec<BlockHash> {
+    Result::<_>::unwrap(task::block_in_place(|| {
+        let client = Client::new(BITCOIND_RPC_URL, nigiri_rpc_auth())?;
+        let address = match to_address {
+            Some(address) => address,
+            None => &client.get_new_address(None, None)?.assume_checked()
+        };
+        Ok(client.generate_to_address(block_num, address)?)
+    }))
+}
+
+async fn start_wallet_service_with_nigiri_permit() -> (Arc<impl WalletService>, AbortOnDropHandle<impl Sized>, NigiriPermit) {
+    let permit = start_nigiri_with_permit().await.unwrap();
+
+    let wallet_service = Arc::new(WalletServiceImpl::create_with_rpc_params(
+        nigiri_rpc_auth(), BITCOIND_POLLING_PERIOD));
+    assert_eq!(wallet_service.balance(), Balance::default());
+
+    let guard = AbortOnDropHandle::new(wallet_service.clone().spawn_connection());
+    // Wait for RPC sync...
+    // FIXME: A bit hacky -- should add logic to the service to notify when the wallet is synced.
+    time::sleep(Duration::from_secs(1)).await;
+
+    (wallet_service, guard, permit)
+}
+
+fn nigiri_rpc_auth() -> Auth { Auth::UserPass("admin1".into(), "123".into()) }
+
+type NigiriPermit = (&'static NigiriConfig, SemaphorePermit<'static>);
+
+async fn start_nigiri_with_permit() -> Result<NigiriPermit> {
+    static PERMIT: Semaphore = Semaphore::const_new(1);
+
+    Ok((start_nigiri().await?, PERMIT.acquire().await?))
+}
+
+async fn start_nigiri() -> Result<&'static NigiriConfig> {
+    static ONCE: OnceCell<NigiriConfig> = OnceCell::const_new();
+
+    ONCE.get_or_try_init(|| async {
+        task::spawn_blocking(|| {
+            if let Ok(config) = read_started_nigiri_config() {
+                // Nigiri is already started, possibly externally -- assume all its components are
+                // actually fully started and not in the process of shutting down.
+                return Ok(config);
+            }
+            let output = Command::new("nigiri")
+                .arg("--datadir").arg(fs::canonicalize(".nigiri")?)
+                .args(["start", "--ci"])
+                .output()?;
+            if !output.status.success() {
+                bail!("Could not start nigiri: {output:#?}");
+            }
+            let config = read_started_nigiri_config()?;
+            // We have to wait for bitcoind to finish starting up, even though Nigiri is already
+            // started, as otherwise JSON-RPC calls to it will fail with a "Loading wallet…" error.
+            // FIXME: A bit hacky - can we poll for a 'ready' status?
+            std::thread::sleep(Duration::from_secs(2));
+            Ok(config)
+        }).await?
+    }).await
+}
+
+fn read_nigiri_config() -> Result<NigiriConfig> {
+    let config_result = fs::read_to_string(".nigiri/nigiri.config.json");
+    Ok(serde_json::from_str(&config_result?)?)
+}
+
+fn read_started_nigiri_config() -> Result<NigiriConfig> {
+    read_nigiri_config()?.check_started()
+}
+
+#[derive(Debug, Deserialize)]
+struct NigiriConfig(HashMap<String, String>);
+
+impl NigiriConfig {
+    fn is_started(&self) -> bool {
+        self.0.get("ready").map(String::as_str) == Some("true") &&
+            self.0.get("running").map(String::as_str) == Some("true")
+    }
+
+    fn check_started(self) -> Result<Self> {
+        if !self.is_started() {
+            bail!("Unstarted nigiri config: {self:#?}");
+        }
+        Ok(self)
+    }
+}


### PR DESCRIPTION
Add an integration test crate, `tests/wallet_service.rs`, for the underlying wallet service implementation in the `rpc` crate (distinct from the gRPC handlers which wrap it), which connects (via the JSON-RPC backend) to the bitcoind regtest Docker container provided with [Nigiri](https://github.com/vulpemventures/nigiri). At present, there is just one test which sends some unconfirmed BTC from the bitcoind wallet to a fresh Rust wallet address (using a `sendtoaddress` JSON-RPC call), then mines a block to check that the confirmation count (from its tx confidence stream) moves from 0 to 1, and that the wallet balance updates correctly. (More tests will likely be added as the wallet gRPC service gets further developed.)

Also expand the tests in `tests/cli.rs`, which now expect JSON responses from the `musig-cli` command-line interface. This gives greatly improved readability over the present `Debug`-formatted output for txid/raw-tx byte arrays and utxo lists. Modify `build.rs` to provide the necessary Serde attributes to the protobuf Rust codegen to achieve this.

--

Additionally, fix a few minor code issues (hypothetical space leak in `observable.rs` and Clippy warnings with Rust 1.87).

Finally, make some smallish changes to ease integration testing with Bisq2:

- Add `--port` option to allow separate `musigd` instances for Alice and Bob traders.
- Bring `rpc.proto` into sync with Bisq2 modifications, adding a mock `Musig.SubscribeTxConfirmationStatus` service method and updating `TradeProtocolClient.java` accordingly.
