### PR TITLE
Add mock-protocol tx builders, missing Taproot tweaks, optional trade fee & Claim Txs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -975,7 +975,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1400,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1410,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
  "itertools",
@@ -1423,6 +1423,8 @@ dependencies = [
  "prettyplease",
  "prost",
  "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
  "syn",
  "tempfile",
@@ -1430,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1443,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
  "prost",
 ]
@@ -1460,6 +1462,26 @@ dependencies = [
  "dotenv",
  "musig2",
  "rand 0.9.2",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5b6a0769a491a08b31ea5c62494a8f144ee0987d86d670a8af4df1e1b7cde75"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -1630,6 +1652,7 @@ dependencies = [
  "predicates",
  "prost",
  "protocol",
+ "rand 0.9.2",
  "rpc",
  "serde",
  "serde_with",
@@ -1637,7 +1660,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "tracing",
  "tracing-subscriber",
  "unimock",
@@ -1645,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
@@ -1891,16 +1915,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -2019,9 +2033,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2030,9 +2044,9 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "slab",
- "socket2 0.5.10",
+ "socket2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2072,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+checksum = "308e1db96abdccdf0a9150fb69112bf6ea72640e0bd834ef0c4a618ccc8c8ddc"
 dependencies = [
  "async-trait",
  "axum",
@@ -2089,8 +2103,8 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
- "socket2 0.5.10",
+ "socket2",
+ "sync_wrapper",
  "tokio",
  "tokio-stream",
  "tower",
@@ -2101,9 +2115,32 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
+checksum = "18262cdd13dec66e8e3f2e3fe535e4b2cc706fab444a7d3678d75d8ac2557329"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d8b5b7a44512c59f5ad45e0c40e53263cbbf4426d74fe6b569e04f1d4206e9c"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "114cca66d757d72422ef8cccf8be3065321860ac9fa4be73aab37a8a20a9a805"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2111,6 +2148,8 @@ dependencies = [
  "prost-types",
  "quote",
  "syn",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]
@@ -2216,6 +2255,12 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -2478,7 +2523,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2499,10 +2544,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -85,22 +85,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -314,9 +314,9 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.6"
+version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8929a18b8e33ea6b3c09297b687baaa71fb1b97353243a3f1029fad5c59c5b"
+checksum = "0fda569d741b895131a88ee5589a467e73e9c4718e958ac9308e4f7dc44b6945"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
@@ -437,9 +437,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
 dependencies = [
  "shlex",
 ]
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -475,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1267,6 +1267,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,6 +1655,7 @@ dependencies = [
  "drop-stream",
  "futures-util",
  "musig2",
+ "paste",
  "predicates",
  "prost",
  "protocol",
@@ -1688,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "log",
  "once_cell",
@@ -1833,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -2033,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2073,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,9 @@ members = ["protocol", "rpc"]
 exclude = ["adaptor", "bdktest"]
 
 [workspace.dependencies]
+anyhow = "1.0.98"
 bdk_bitcoind_rpc = "0.20.0"
 bdk_electrum = { version = "0.23.0", default-features = false, features = ["use-rustls-ring"] }
 bdk_wallet = "2.0.0"
 musig2 = { version = "0.3.1", features = ["rand"] }
+rand = "0.9.2"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+anyhow = { workspace = true }
 bdk_electrum = { workspace = true }
-anyhow = "1.0.97"
-dotenv = "0.15.0"
 bdk_wallet = { workspace = true }
-rand = "0.9.0"
+dotenv = "0.15.0"
 musig2 = { workspace = true }
+rand = { workspace = true }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -11,13 +11,14 @@ bdk_wallet = { workspace = true }
 drop-stream = "0.3.2"
 futures-util = { version = "0.3.31", default-features = false, features = ["alloc"] }
 musig2 = { workspace = true }
+paste = "1.0.15"
 prost = "0.14.1"
 protocol = { path = "../protocol" }
 rand = { workspace = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_with = { version = "3.14.0", features = ["hex"] }
 thiserror = "2.0.12"
-tokio = { version = "1.47.0", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "time"] }
 tokio-stream = "0.1.17"
 tonic = "0.14.0"
 tonic-prost = "0.14.0"
@@ -25,7 +26,7 @@ tracing = "0.1.41"
 unimock = { version = "0.6.7", optional = true }
 # Dependencies used only by the binary target(s):
 # TODO: Consider making a workspace of separate packages to avoid pulling these into the library:
-clap = { version = "4.5.41", features = ["derive"] }
+clap = { version = "4.5.42", features = ["derive"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [build-dependencies]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -10,14 +10,16 @@ bdk_wallet = { workspace = true }
 drop-stream = "0.3.2"
 futures-util = { version = "0.3.31", default-features = false, features = ["alloc"] }
 musig2 = { workspace = true }
-prost = "0.13.5"
+prost = "0.14.1"
 protocol = { path = "../protocol" }
+rand = { workspace = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_with = { version = "3.14.0", features = ["hex"] }
 thiserror = "2.0.12"
-tokio = { version = "1.46.1", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.47.0", features = ["macros", "rt-multi-thread", "time"] }
 tokio-stream = "0.1.17"
-tonic = "0.13.1"
+tonic = "0.14.0"
+tonic-prost = "0.14.0"
 tracing = "0.1.41"
 unimock = { version = "0.6.7", optional = true }
 # Dependencies used only by the binary target(s):
@@ -26,11 +28,11 @@ clap = { version = "4.5.41", features = ["derive"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [build-dependencies]
-tonic-build = "0.13.1"
+tonic-prost-build = "0.14.0"
 
 [dev-dependencies]
 rpc = { path = ".", features = ["unimock"] }
-anyhow = "1.0.98"
+anyhow = { workspace = true }
 assert_cmd = "2.0.17"
 const_format = "0.2.34"
 predicates = "3.1.3"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rpc"
 version = "0.1.0"
+# Hold at 2021 for now, since adapting to Rust 2024 needs syntax that the open source IDEA Rust plugin can't yet handle:
 edition = "2021"
 default-run = "musig-cli"
 
@@ -36,6 +37,11 @@ anyhow = { workspace = true }
 assert_cmd = "2.0.17"
 const_format = "0.2.34"
 predicates = "3.1.3"
+
+[lints.rust]
+rust-2024-compatibility = "warn"
+# Most of the time, changing drop order is harmless ('rust-2024-compatibility' lint):
+tail_expr_drop_order = { level = "allow", priority = 1 }
 
 [lints.clippy]
 pedantic = "warn"

--- a/rpc/build.rs
+++ b/rpc/build.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .serde_serialized_types(&["WalletBalanceResponse", "NewAddressResponse", "ListUnspentResponse"])
         .serde_serialized_type("TransactionOutput", &[
             rev_hex("txId"), hex("scriptPubKey")
@@ -51,7 +51,7 @@ trait BuilderEx {
     }
 }
 
-impl BuilderEx for tonic_build::Builder {
+impl BuilderEx for tonic_prost_build::Builder {
     fn serde_serialized_enum(self, path: &str) -> Self {
         self.enum_attribute(path, "#[derive(::serde::Serialize)]")
             .enum_attribute(path, "#[serde(rename_all = \"SCREAMING_SNAKE_CASE\")]")

--- a/rpc/clippy.toml
+++ b/rpc/clippy.toml
@@ -1,3 +1,0 @@
-# For Rust 1.87 until fixed: Prevent perf warnings due to `tonic::Result::Err`-variant >=176 bytes.
-# See: https://github.com/hyperium/tonic/issues/2253
-large-error-threshold = 256

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -11,4 +11,5 @@ mod observable;
 mod protocol;
 pub mod server;
 mod storage;
+mod transaction;
 pub mod wallet;

--- a/rpc/src/main/proto/rpc.proto
+++ b/rpc/src/main/proto/rpc.proto
@@ -47,6 +47,7 @@ message NonceSharesRequest {
   uint64 tradeAmount = 6;            // sats
   uint64 buyersSecurityDeposit = 7;  // sats
   uint64 sellersSecurityDeposit = 8; // sats
+  ReceiverAddressAndAmount tradeFeeReceiver = 9;
 }
 
 message NonceSharesMessage {
@@ -54,6 +55,7 @@ message NonceSharesMessage {
   string redirectTxFeeBumpAddress = 2;
   string claimTxPayoutAddress = 11;
   bytes halfDepositPsbt = 3;
+  uint64 redirectionAmountMsat = 14; // (millisatoshis)
   bytes swapTxInputNonceShare = 4;
   bytes buyersWarningTxBuyerInputNonceShare = 5;
   bytes buyersWarningTxSellerInputNonceShare = 6;
@@ -73,7 +75,7 @@ message ReceiverAddressAndAmount {
 message PartialSignaturesRequest {
   string tradeId = 1;
   NonceSharesMessage peersNonceShares = 2;
-  repeated ReceiverAddressAndAmount receivers = 3;
+  repeated ReceiverAddressAndAmount redirectionReceivers = 3;
   bool buyerReadyToRelease = 4;
 }
 

--- a/rpc/src/main/proto/rpc.proto
+++ b/rpc/src/main/proto/rpc.proto
@@ -52,6 +52,7 @@ message NonceSharesRequest {
 message NonceSharesMessage {
   string warningTxFeeBumpAddress = 1;
   string redirectTxFeeBumpAddress = 2;
+  string claimTxPayoutAddress = 11;
   bytes halfDepositPsbt = 3;
   bytes swapTxInputNonceShare = 4;
   bytes buyersWarningTxBuyerInputNonceShare = 5;
@@ -60,6 +61,8 @@ message NonceSharesMessage {
   bytes sellersWarningTxSellerInputNonceShare = 8;
   bytes buyersRedirectTxInputNonceShare = 9;
   bytes sellersRedirectTxInputNonceShare = 10;
+  bytes buyersClaimTxInputNonceShare = 12;
+  bytes sellersClaimTxInputNonceShare = 13;
 }
 
 message ReceiverAddressAndAmount {
@@ -78,6 +81,7 @@ message PartialSignaturesMessage {
   bytes peersWarningTxBuyerInputPartialSignature = 1;
   bytes peersWarningTxSellerInputPartialSignature = 2;
   bytes peersRedirectTxInputPartialSignature = 3;
+  bytes peersClaimTxInputPartialSignature = 6;
   optional bytes swapTxInputPartialSignature = 4;
   optional bytes swapTxInputSighash = 5;
 }

--- a/rpc/src/observable.rs
+++ b/rpc/src/observable.rs
@@ -27,7 +27,9 @@ impl<T> Observable<T> {
 }
 
 impl<T: Clone> Observable<T> {
-    pub fn observe(&mut self) -> impl Stream<Item=T> {
+    #[expect(impl_trait_overcaptures,
+    reason = "need to append `+ use<T>` to get correct semantics with Rust 2024 (but breaks IDE)")]
+    pub fn observe(&mut self) -> impl Stream<Item=T> { // + use<T> {
         let (tx, rx) = mpsc::unbounded_channel();
         tx.send(self.value.clone()).unwrap();
         self.senders.push(tx);
@@ -75,7 +77,9 @@ impl<K, V> ObservableHashMap<K, V>
     where K: Eq + Hash,
           V: Clone
 {
-    pub fn observe(&mut self, key: K) -> impl Stream<Item=Option<V>> {
+    #[expect(impl_trait_overcaptures,
+    reason = "need to append `+ use<K, V>` to get correct semantics with Rust 2024 (but breaks IDE)")]
+    pub fn observe(&mut self, key: K) -> impl Stream<Item=Option<V>> { // + use<K, V> {
         match self.map.entry(key) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => entry.insert(Observable::default())

--- a/rpc/src/pb/convert.rs
+++ b/rpc/src/pb/convert.rs
@@ -16,9 +16,10 @@ use crate::pb::walletrpc::{
     ConfEvent, ConfidenceType, ConfirmationBlockTime, TransactionOutput, WalletBalanceResponse,
 };
 use crate::protocol::{
-    ExchangedAddresses, ExchangedNonces, ExchangedSigs, ProtocolErrorKind, Receiver, Role,
+    ExchangedAddresses, ExchangedNonces, ExchangedSigs, ProtocolErrorKind, Role,
 };
 use crate::storage::{ByRef, ByVal};
+use crate::transaction::Receiver;
 use crate::wallet::TxConfidence;
 
 pub(crate) mod hex {

--- a/rpc/src/pb/convert.rs
+++ b/rpc/src/pb/convert.rs
@@ -16,8 +16,7 @@ use crate::pb::walletrpc::{
     ConfEvent, ConfidenceType, ConfirmationBlockTime, TransactionOutput, WalletBalanceResponse,
 };
 use crate::protocol::{
-    ExchangedAddresses, ExchangedNonces, ExchangedSigs, ProtocolErrorKind, RedirectionReceiver,
-    Role,
+    ExchangedAddresses, ExchangedNonces, ExchangedSigs, ProtocolErrorKind, Receiver, Role,
 };
 use crate::storage::{ByRef, ByVal};
 use crate::wallet::TxConfidence;
@@ -111,9 +110,9 @@ impl TryProtoInto<Address<NetworkUnchecked>> for &str {
     }
 }
 
-impl TryProtoInto<RedirectionReceiver<NetworkUnchecked>> for ReceiverAddressAndAmount {
-    fn try_proto_into(self) -> Result<RedirectionReceiver<NetworkUnchecked>> {
-        Ok(RedirectionReceiver {
+impl TryProtoInto<Receiver<NetworkUnchecked>> for ReceiverAddressAndAmount {
+    fn try_proto_into(self) -> Result<Receiver<NetworkUnchecked>> {
+        Ok(Receiver {
             address: self.address.try_proto_into()?,
             amount: Amount::from_sat(self.amount),
         })
@@ -206,8 +205,9 @@ impl From<musigrpc::Role> for Role {
 impl From<SentAddressesNoncesPair<'_>> for NonceSharesMessage {
     fn from((addresses, nonces): SentAddressesNoncesPair) -> Self {
         Self {
-            // Use default value for the half-deposit PSBT field. TODO: A little hacky; consider refactoring proto.
+            // Use default value for the PSBT & redirection amount fields. TODO: A little hacky; consider refactoring proto.
             half_deposit_psbt: Vec::default(),
+            redirection_amount_msat: 0,
             // Addresses...
             warning_tx_fee_bump_address: addresses.warning_tx_fee_bump_address.to_string(),
             redirect_tx_fee_bump_address: addresses.redirect_tx_fee_bump_address.to_string(),

--- a/rpc/src/pb/convert.rs
+++ b/rpc/src/pb/convert.rs
@@ -16,7 +16,8 @@ use crate::pb::walletrpc::{
     ConfEvent, ConfidenceType, ConfirmationBlockTime, TransactionOutput, WalletBalanceResponse,
 };
 use crate::protocol::{
-    ExchangedNonces, ExchangedSigs, ProtocolErrorKind, RedirectionReceiver, Role,
+    ExchangedAddresses, ExchangedNonces, ExchangedSigs, ProtocolErrorKind, RedirectionReceiver,
+    Role,
 };
 use crate::storage::{ByRef, ByVal};
 use crate::wallet::TxConfidence;
@@ -52,6 +53,18 @@ macro_rules! impl_try_proto_into_for_slice {
                     Status::invalid_argument(format!("could not decode {}: {e}", $err_msg))
                 })
             }
+        }
+    };
+}
+
+macro_rules! empty_to_none {
+    ($self:ident.$field:ident) => {
+        if $self.$field.is_empty() {
+            let name = stringify!($field);
+            tracing::warn!(name, "Empty proto field.");
+            None
+        } else {
+            Some($self.$field)
         }
     };
 }
@@ -111,6 +124,10 @@ impl<T> TryProtoInto<T> for Vec<u8> where for<'a> &'a [u8]: TryProtoInto<T> {
     fn try_proto_into(self) -> Result<T> { (&self[..]).try_proto_into() }
 }
 
+impl<T> TryProtoInto<T> for String where for<'a> &'a str: TryProtoInto<T> {
+    fn try_proto_into(self) -> Result<T> { (&self[..]).try_proto_into() }
+}
+
 impl<T, S: TryProtoInto<T>> TryProtoInto<Option<T>> for Option<S> {
     fn try_proto_into(self) -> Result<Option<T>> {
         Ok(match self {
@@ -120,9 +137,20 @@ impl<T, S: TryProtoInto<T>> TryProtoInto<Option<T>> for Option<S> {
     }
 }
 
-impl<'a> TryProtoInto<ExchangedNonces<'a, ByVal>> for NonceSharesMessage {
-    fn try_proto_into(self) -> Result<ExchangedNonces<'a, ByVal>> {
-        Ok(ExchangedNonces {
+type SentAddressesNoncesPair<'a> = (ExchangedAddresses<'a, ByRef>, ExchangedNonces<'a, ByRef>);
+
+type ReceivedAddressesNoncesPair<'a> = (ExchangedAddresses<'a, ByVal, NetworkUnchecked>, ExchangedNonces<'a, ByVal>);
+
+impl<'a> TryProtoInto<ReceivedAddressesNoncesPair<'a>> for NonceSharesMessage {
+    fn try_proto_into(self) -> Result<ReceivedAddressesNoncesPair<'a>> {
+        Ok((ExchangedAddresses {
+            warning_tx_fee_bump_address:
+            self.warning_tx_fee_bump_address.try_proto_into()?,
+            redirect_tx_fee_bump_address:
+            self.redirect_tx_fee_bump_address.try_proto_into()?,
+            claim_tx_payout_address:
+            empty_to_none!(self.claim_tx_payout_address).try_proto_into()?,
+        }, ExchangedNonces {
             swap_tx_input_nonce_share:
             self.swap_tx_input_nonce_share.try_proto_into()?,
             buyers_warning_tx_buyer_input_nonce_share:
@@ -137,7 +165,11 @@ impl<'a> TryProtoInto<ExchangedNonces<'a, ByVal>> for NonceSharesMessage {
             self.buyers_redirect_tx_input_nonce_share.try_proto_into()?,
             sellers_redirect_tx_input_nonce_share:
             self.sellers_redirect_tx_input_nonce_share.try_proto_into()?,
-        })
+            buyers_claim_tx_input_nonce_share:
+            empty_to_none!(self.buyers_claim_tx_input_nonce_share).try_proto_into()?,
+            sellers_claim_tx_input_nonce_share:
+            empty_to_none!(self.sellers_claim_tx_input_nonce_share).try_proto_into()?,
+        }))
     }
 }
 
@@ -150,6 +182,8 @@ impl<'a> TryProtoInto<ExchangedSigs<'a, ByVal>> for PartialSignaturesMessage {
             self.peers_warning_tx_seller_input_partial_signature.try_proto_into()?,
             peers_redirect_tx_input_partial_signature:
             self.peers_redirect_tx_input_partial_signature.try_proto_into()?,
+            peers_claim_tx_input_partial_signature:
+            empty_to_none!(self.peers_claim_tx_input_partial_signature).try_proto_into()?,
             swap_tx_input_partial_signature:
             self.swap_tx_input_partial_signature.try_proto_into()?,
             swap_tx_input_sighash:
@@ -169,28 +203,34 @@ impl From<musigrpc::Role> for Role {
     }
 }
 
-impl From<ExchangedNonces<'_, ByRef>> for NonceSharesMessage {
-    fn from(value: ExchangedNonces<ByRef>) -> Self {
+impl From<SentAddressesNoncesPair<'_>> for NonceSharesMessage {
+    fn from((addresses, nonces): SentAddressesNoncesPair) -> Self {
         Self {
-            // Use default values for proto fields besides the nonce shares. TODO: A little hacky; consider refactoring proto.
-            warning_tx_fee_bump_address: String::default(),
-            redirect_tx_fee_bump_address: String::default(),
+            // Use default value for the half-deposit PSBT field. TODO: A little hacky; consider refactoring proto.
             half_deposit_psbt: Vec::default(),
+            // Addresses...
+            warning_tx_fee_bump_address: addresses.warning_tx_fee_bump_address.to_string(),
+            redirect_tx_fee_bump_address: addresses.redirect_tx_fee_bump_address.to_string(),
+            claim_tx_payout_address: addresses.claim_tx_payout_address.map(Address::to_string).unwrap_or_default(),
             // Actual nonce shares...
             swap_tx_input_nonce_share:
-            value.swap_tx_input_nonce_share.serialize().into(),
+            nonces.swap_tx_input_nonce_share.serialize().into(),
             buyers_warning_tx_buyer_input_nonce_share:
-            value.buyers_warning_tx_buyer_input_nonce_share.serialize().into(),
+            nonces.buyers_warning_tx_buyer_input_nonce_share.serialize().into(),
             buyers_warning_tx_seller_input_nonce_share:
-            value.buyers_warning_tx_seller_input_nonce_share.serialize().into(),
+            nonces.buyers_warning_tx_seller_input_nonce_share.serialize().into(),
             sellers_warning_tx_buyer_input_nonce_share:
-            value.sellers_warning_tx_buyer_input_nonce_share.serialize().into(),
+            nonces.sellers_warning_tx_buyer_input_nonce_share.serialize().into(),
             sellers_warning_tx_seller_input_nonce_share:
-            value.sellers_warning_tx_seller_input_nonce_share.serialize().into(),
+            nonces.sellers_warning_tx_seller_input_nonce_share.serialize().into(),
             buyers_redirect_tx_input_nonce_share:
-            value.buyers_redirect_tx_input_nonce_share.serialize().into(),
+            nonces.buyers_redirect_tx_input_nonce_share.serialize().into(),
             sellers_redirect_tx_input_nonce_share:
-            value.sellers_redirect_tx_input_nonce_share.serialize().into(),
+            nonces.sellers_redirect_tx_input_nonce_share.serialize().into(),
+            buyers_claim_tx_input_nonce_share:
+            nonces.buyers_claim_tx_input_nonce_share.map(|n| n.serialize().into()).unwrap_or_default(),
+            sellers_claim_tx_input_nonce_share:
+            nonces.sellers_claim_tx_input_nonce_share.map(|n| n.serialize().into()).unwrap_or_default(),
         }
     }
 }
@@ -204,6 +244,8 @@ impl From<ExchangedSigs<'_, ByRef>> for PartialSignaturesMessage {
             value.peers_warning_tx_seller_input_partial_signature.serialize().into(),
             peers_redirect_tx_input_partial_signature:
             value.peers_redirect_tx_input_partial_signature.serialize().into(),
+            peers_claim_tx_input_partial_signature:
+            value.peers_claim_tx_input_partial_signature.map(|s| s.serialize().into()).unwrap_or_default(),
             swap_tx_input_partial_signature:
             value.swap_tx_input_partial_signature.map(|s| s.serialize().into()),
             swap_tx_input_sighash:

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -3,7 +3,6 @@ use bdk_wallet::bitcoin::hashes::Hash as _;
 use bdk_wallet::bitcoin::{Address, Amount, FeeRate, Network, Psbt, TapSighash};
 use musig2::adaptor::AdaptorSignature;
 use musig2::secp::{MaybePoint, MaybeScalar, Point, Scalar};
-use musig2::secp256k1::rand;
 use musig2::{
     AggNonce, KeyAggContext, LiftedSignature, NonceSeed, PartialSignature, PubNonce, SecNonce,
     SecNonceBuilder,

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -58,9 +58,9 @@ impl musig_server::Musig for MusigImpl {
                 request.buyer_output_peers_pub_key_share.try_proto_into()?,
                 request.seller_output_peers_pub_key_share.try_proto_into()?);
             trade_model.aggregate_key_shares()?;
-            trade_model.trade_amount = Some(Amount::from_sat(request.trade_amount));
-            trade_model.buyers_security_deposit = Some(Amount::from_sat(request.buyers_security_deposit));
-            trade_model.sellers_security_deposit = Some(Amount::from_sat(request.sellers_security_deposit));
+            trade_model.set_trade_amount(Amount::from_sat(request.trade_amount));
+            trade_model.set_buyers_security_deposit(Amount::from_sat(request.buyers_security_deposit));
+            trade_model.set_sellers_security_deposit(Amount::from_sat(request.sellers_security_deposit));
             trade_model.set_deposit_tx_fee_rate(FeeRate::from_sat_per_kwu(request.deposit_tx_fee_rate));
             trade_model.set_prepared_tx_fee_rate(FeeRate::from_sat_per_kwu(request.prepared_tx_fee_rate));
             trade_model.set_trade_fee_receiver(request.trade_fee_receiver.try_proto_into()?)?;

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -63,22 +63,20 @@ impl musig_server::Musig for MusigImpl {
             trade_model.sellers_security_deposit = Some(Amount::from_sat(request.sellers_security_deposit));
             trade_model.deposit_tx_fee_rate = Some(FeeRate::from_sat_per_kwu(request.deposit_tx_fee_rate));
             trade_model.prepared_tx_fee_rate = Some(FeeRate::from_sat_per_kwu(request.prepared_tx_fee_rate));
-            trade_model.init_my_fee_bump_addresses()?;
+            trade_model.init_my_addresses()?;
             trade_model.init_my_half_deposit_psbt()?;
             trade_model.init_my_nonce_shares()?;
 
-            let my_fee_bump_addresses = trade_model.get_my_fee_bump_addresses()
-                .ok_or_else(|| Status::internal("missing fee bump addresses"))?;
+            let my_addresses = trade_model.get_my_addresses()
+                .ok_or_else(|| Status::internal("missing addresses"))?;
             let my_half_deposit_psbt = trade_model.get_my_half_deposit_psbt()
                 .ok_or_else(|| Status::internal("missing half deposit PSBT"))?;
             let my_nonce_shares = trade_model.get_my_nonce_shares()
                 .ok_or_else(|| Status::internal("missing nonce shares"))?;
 
             Ok(NonceSharesMessage {
-                warning_tx_fee_bump_address: my_fee_bump_addresses[0].to_string(),
-                redirect_tx_fee_bump_address: my_fee_bump_addresses[1].to_string(),
                 half_deposit_psbt: my_half_deposit_psbt.serialize(),
-                ..my_nonce_shares.into()
+                ..(my_addresses, my_nonce_shares).into()
             })
         })
     }
@@ -94,13 +92,11 @@ impl musig_server::Musig for MusigImpl {
             }
             let peer_nonce_shares = request.peers_nonce_shares
                 .ok_or_else(|| Status::not_found("missing request.peers_nonce_shares"))?;
-            trade_model.set_peer_fee_bump_addresses([
-                (&peer_nonce_shares.warning_tx_fee_bump_address).try_proto_into()?,
-                (&peer_nonce_shares.redirect_tx_fee_bump_address).try_proto_into()?
-            ])?;
             trade_model.set_peer_half_deposit_psbt((&peer_nonce_shares.half_deposit_psbt[..]).try_proto_into()?);
             trade_model.set_redirection_receivers(request.receivers.into_iter().map(TryProtoInto::try_proto_into))?;
-            trade_model.set_peer_nonce_shares(peer_nonce_shares.try_proto_into()?);
+            let (addresses, nonce_shares) = peer_nonce_shares.try_proto_into()?;
+            trade_model.set_peer_addresses(addresses)?;
+            trade_model.set_peer_nonce_shares(nonce_shares);
             trade_model.aggregate_nonce_shares()?;
             trade_model.sign_partial()?;
             let my_partial_signatures = trade_model

--- a/rpc/src/transaction.rs
+++ b/rpc/src/transaction.rs
@@ -1,11 +1,12 @@
+use bdk_wallet::bitcoin::address::{NetworkChecked, NetworkUnchecked, NetworkValidation};
 use bdk_wallet::bitcoin::amount::CheckedSum as _;
 use bdk_wallet::bitcoin::opcodes::all::{OP_CHECKSIG, OP_CSV, OP_DROP};
 use bdk_wallet::bitcoin::sighash::{Prevouts, SighashCache};
 use bdk_wallet::bitcoin::taproot::TaprootBuilder;
 use bdk_wallet::bitcoin::transaction::Version;
 use bdk_wallet::bitcoin::{
-    absolute, relative, script, Address, Amount, FeeRate, OutPoint, ScriptBuf, TapNodeHash,
-    TapSighash, TapSighashType, Transaction, TxIn, TxOut, Weight, XOnlyPublicKey,
+    absolute, relative, script, Address, Amount, FeeRate, Network, OutPoint, ScriptBuf,
+    TapNodeHash, TapSighash, TapSighashType, Transaction, TxIn, TxOut, Weight, XOnlyPublicKey,
 };
 use paste::paste;
 use relative::LockTime;
@@ -37,6 +38,46 @@ pub fn warning_output_merkle_root(claim_pub_key: &XOnlyPublicKey, claim_lock_tim
         .try_into_taptree()
         .expect("hardcoded TapTree build sequence should be complete")
         .root_hash()
+}
+
+pub struct Receiver<V: NetworkValidation = NetworkChecked> {
+    pub address: Address<V>,
+    pub amount: Amount,
+}
+
+impl Receiver<NetworkUnchecked> {
+    pub fn require_network(self, required: Network) -> Result<Receiver> {
+        Ok(Receiver { address: self.address.require_network(required)?, amount: self.amount })
+    }
+}
+
+impl Receiver {
+    fn output_weight(&self) -> Weight {
+        Weight::from_vb_unchecked(self.address.script_pubkey().len() as u64 + 9)
+    }
+
+    fn output_cost_msat(&self, fee_rate: FeeRate) -> Option<u64> {
+        let amount_msat = self.amount.to_sat().checked_mul(1000)?;
+        let fee_msat = fee_rate.to_sat_per_kwu().checked_mul(self.output_weight().to_wu())?;
+        amount_msat.checked_add(fee_msat)
+    }
+
+    pub fn total_output_cost_msat<'a, I>(receivers: I, fee_rate: FeeRate, extra_output_num: u16) -> Option<u64>
+        where I: IntoIterator<Item=&'a Self>
+    {
+        let mut cost = 0u64;
+        let mut num = extra_output_num;
+        for receiver in receivers {
+            cost = cost.checked_add(receiver.output_cost_msat(fee_rate)?)?;
+            // Fail if more than 65535 outputs, which will never happen for a standard tx:
+            num = num.checked_add(1)?;
+        }
+        if num > 252 {
+            // For more than 252 outputs, we get a 3-byte length encoding instead of 1, adding 8 wu.
+            cost = cost.checked_add(fee_rate.to_sat_per_kwu().checked_mul(8)?)?;
+        }
+        Some(cost)
+    }
 }
 
 macro_rules! make_getter {

--- a/rpc/src/transaction.rs
+++ b/rpc/src/transaction.rs
@@ -1,9 +1,16 @@
 use bdk_wallet::bitcoin::opcodes::all::{OP_CHECKSIG, OP_CSV, OP_DROP};
 use bdk_wallet::bitcoin::taproot::TaprootBuilder;
-use bdk_wallet::bitcoin::{relative, script, ScriptBuf, TapNodeHash, XOnlyPublicKey};
+use bdk_wallet::bitcoin::{
+    relative, script, Amount, ScriptBuf, TapNodeHash, Weight, XOnlyPublicKey,
+};
 use relative::LockTime;
 
 pub const REGTEST_CLAIM_LOCK_TIME: LockTime = LockTime::from_height(5);
+pub const ANCHOR_AMOUNT: Amount = Amount::from_sat(330);
+pub const SIGNED_SWAP_TX_WEIGHT: Weight = Weight::from_wu(444);
+pub const SIGNED_WARNING_TX_WEIGHT: Weight = Weight::from_wu(846);
+pub const SIGNED_REDIRECT_TX_BASE_WEIGHT: Weight = SIGNED_SWAP_TX_WEIGHT;
+// pub const SIGNED_CLAIM_TX_WEIGHT: Weight = SIGNED_SWAP_TX_WEIGHT;
 
 fn claim_script(pub_key: &XOnlyPublicKey, lock_time: LockTime) -> ScriptBuf {
     script::Builder::new()

--- a/rpc/src/transaction.rs
+++ b/rpc/src/transaction.rs
@@ -1,10 +1,17 @@
+use bdk_wallet::bitcoin::amount::CheckedSum as _;
 use bdk_wallet::bitcoin::opcodes::all::{OP_CHECKSIG, OP_CSV, OP_DROP};
+use bdk_wallet::bitcoin::sighash::{Prevouts, SighashCache};
 use bdk_wallet::bitcoin::taproot::TaprootBuilder;
+use bdk_wallet::bitcoin::transaction::Version;
 use bdk_wallet::bitcoin::{
-    relative, script, Amount, ScriptBuf, TapNodeHash, Weight, XOnlyPublicKey,
+    absolute, relative, script, Address, Amount, FeeRate, OutPoint, ScriptBuf, TapNodeHash,
+    TapSighash, TapSighashType, Transaction, TxIn, TxOut, Weight, XOnlyPublicKey,
 };
+use paste::paste;
 use relative::LockTime;
+use thiserror::Error;
 
+pub const REGTEST_WARNING_LOCK_TIME: LockTime = LockTime::from_height(5);
 pub const REGTEST_CLAIM_LOCK_TIME: LockTime = LockTime::from_height(5);
 pub const ANCHOR_AMOUNT: Amount = Amount::from_sat(330);
 pub const SIGNED_SWAP_TX_WEIGHT: Weight = Weight::from_wu(444);
@@ -30,4 +37,235 @@ pub fn warning_output_merkle_root(claim_pub_key: &XOnlyPublicKey, claim_lock_tim
         .try_into_taptree()
         .expect("hardcoded TapTree build sequence should be complete")
         .root_hash()
+}
+
+macro_rules! make_getter {
+    ($field_name:ident: $field_type:ident) => {
+        paste! {
+            pub fn $field_name(&self) -> Result<&$field_type> {
+                self.$field_name.as_ref().ok_or(TransactionErrorKind::[<Missing $field_type>])
+            }
+        }
+    };
+}
+
+macro_rules! make_setter {
+    ($field_name:ident: $field_type:ident) => {
+        paste! {
+            pub fn [<set_ $field_name>](&mut self, $field_name: $field_type) -> &mut Self {
+                self.$field_name.get_or_insert($field_name);
+                self
+            }
+        }
+    };
+}
+
+macro_rules! make_getter_setter {
+    ($field_name:ident: $field_type:ident) => {
+        make_getter!($field_name: $field_type);
+        make_setter!($field_name: $field_type);
+    };
+}
+
+#[derive(Clone)]
+pub struct TxOutput(pub OutPoint, pub TxOut);
+
+#[derive(Default)]
+pub struct WarningTxBuilder {
+    // Supplied fields:
+    buyer_input: Option<TxOutput>,
+    seller_input: Option<TxOutput>,
+    escrow_address: Option<Address>,
+    anchor_address: Option<Address>,
+    warning_lock_time: Option<LockTime>,
+    fee_rate: Option<FeeRate>,
+    // Derived fields:
+    unsigned_tx: Option<Transaction>,
+}
+
+impl WarningTxBuilder {
+    // pub fn new() -> Self { Self::default() }
+
+    make_getter_setter!(buyer_input: TxOutput);
+    make_getter_setter!(seller_input: TxOutput);
+    make_getter_setter!(escrow_address: Address);
+    make_getter_setter!(anchor_address: Address);
+    make_getter_setter!(warning_lock_time: LockTime);
+    make_getter_setter!(fee_rate: FeeRate);
+    make_getter!(unsigned_tx: Transaction);
+
+    pub fn escrow_amount(input_amounts: impl IntoIterator<Item=Amount>, fee_rate: FeeRate) -> Option<Amount> {
+        input_amounts.into_iter().checked_sum()?
+            .checked_sub(ANCHOR_AMOUNT)?
+            .checked_sub(fee_rate.checked_mul_by_weight(SIGNED_WARNING_TX_WEIGHT)?)
+    }
+
+    pub fn compute_unsigned_tx(&mut self) -> Result<&mut Self> {
+        let buyer_input = TxIn {
+            previous_output: self.buyer_input()?.0,
+            sequence: self.warning_lock_time()?.to_sequence(),
+            ..TxIn::default()
+        };
+        let seller_input = TxIn {
+            previous_output: self.seller_input()?.0,
+            sequence: self.warning_lock_time()?.to_sequence(),
+            ..TxIn::default()
+        };
+        let escrow_output = TxOut {
+            value: Self::escrow_amount(
+                [self.buyer_input()?.1.value, self.seller_input()?.1.value],
+                *self.fee_rate()?,
+            ).ok_or(TransactionErrorKind::Overflow)?,
+            script_pubkey: self.escrow_address()?.script_pubkey(),
+        };
+        let anchor_output = TxOut {
+            value: ANCHOR_AMOUNT,
+            script_pubkey: self.anchor_address()?.script_pubkey(),
+        };
+        let tx = Transaction {
+            version: Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![buyer_input, seller_input],
+            output: vec![escrow_output, anchor_output],
+        };
+        self.unsigned_tx.get_or_insert(tx);
+        Ok(self)
+    }
+
+    fn sighash(&self, input_index: usize) -> Result<TapSighash> {
+        let prevouts = [&self.buyer_input()?.1, &self.seller_input()?.1];
+        let prevouts = Prevouts::All(&prevouts);
+        let mut cache = SighashCache::new(self.unsigned_tx()?);
+        Ok(cache.taproot_key_spend_signature_hash(input_index, &prevouts, TapSighashType::All)?)
+    }
+
+    pub fn buyer_input_sighash(&self) -> Result<TapSighash> { self.sighash(0) }
+
+    pub fn seller_input_sighash(&self) -> Result<TapSighash> { self.sighash(1) }
+}
+
+type Result<T, E = TransactionErrorKind> = std::result::Result<T, E>;
+
+#[derive(Error, Debug)]
+#[error(transparent)]
+#[non_exhaustive]
+pub enum TransactionErrorKind {
+    #[error("missing lock time")]
+    MissingLockTime,
+    #[error("missing tx output")]
+    MissingTxOutput,
+    #[error("missing address")]
+    MissingAddress,
+    #[error("missing fee rate")]
+    MissingFeeRate,
+    #[error("missing transaction")]
+    MissingTransaction,
+    #[error("overflow")]
+    Overflow,
+    AddressParse(#[from] bdk_wallet::bitcoin::address::ParseError),
+    Taproot(#[from] bdk_wallet::bitcoin::sighash::TaprootError),
+}
+
+#[cfg(test)]
+mod tests {
+    use bdk_wallet::bitcoin::consensus::Decodable as _;
+    use bdk_wallet::bitcoin::hex::test_hex_unwrap as hex;
+    use bdk_wallet::bitcoin::Network;
+
+    use super::*;
+
+    // Valid signed txs pulled from a Regtest instance. We should be able to rebuild the unsigned parts exactly...
+
+    //noinspection SpellCheckingInspection
+    const SIGNED_DEPOSIT_TX: &str = "\
+        02000000000103593f2490f5fe6ca34151dad53983bb4049fc389a194210377ae9efdeeec871810100000000ffffffff\
+        7d43ef85d23dc54918dc017c805c181f1e3573ce30aedd8492ba4291695da9430100000000ffffffff80dc1d43c34749\
+        26ac5eb7a4def9f1f604225c243f93fa1daa3b2406f4eaf8990000000000ffffffff04707693030000000022512003c4\
+        c490d5b9572f4a8a9a6ba89761efe2d3fb5ab7b48fa49dcd60ab6253bdbf002d310100000000225120523abb34a5f99b\
+        71e2461b119b9c60674a82a25af9aaa9a7dce7cecf79a622f6f3a7c404000000002251209a6474e216ded9220ca2de1d\
+        a86398353cfd8ea00d3798105c6845d49a189b8b003b5808000000002251209c851e4bb082855c30a1441470f57edb2c\
+        e53f74426f14d674e7de0bbcd1fdb301404e855da0d22221e9eeea9b45f42f968d8784bc72e501640e4ec9faa3ada13f\
+        cbb9d7b0e8b42965afba8eef79b8900c0cdc6be6497b535bb1acfadce5413333ef01407c6977dac7717d66b82f0eef90\
+        8a108fd8980bcdf21d08c72062b1dc44933a7b1ff7bb09933fdc9c7174064e287ee863ffcd2fa9836e006aa9323e1751\
+        b5042801405ca211e8014d1df806e220a29a4751c8a362d3e52f09869df93fa43fe322e991d37d58655f8e5c2c0f277e\
+        1015da25c1e533f528d4ba31bfa912c1d166dad36000000000";
+
+    //noinspection SpellCheckingInspection
+    const SIGNED_SELLERS_WARNING_TX: &str = "\
+        020000000001024090929dbeaa475f4fbcb150499bb73f069010e12d4d2a8d76afdf25bd4f82ea030000000002000000\
+        4090929dbeaa475f4fbcb150499bb73f069010e12d4d2a8d76afdf25bd4f82ea01000000000200000002ce6289090000\
+        00002251209c851e4bb082855c30a1441470f57edb2ce53f74426f14d674e7de0bbcd1fdb34a01000000000000225120\
+        fb0caf990c3315e540bef9401ea1bf5c0257a9fc1bc31d8eb4c6e3a50225532e01400a1765c41c6851258c52122f8635\
+        3d4cdc67794707d5a7f79daf9a9441e484f9001eca7a01951ce62fc3eab2fd5a84f45ce3c7ad081fa263ef672cde0a43\
+        7d840140d5f66951bef77e1b3a180b94042604b1e26c0c7bcdecf78b151962dc623963d53e2ac6a77f7ed7be4fc4eab2\
+        3f8decd8196abafb50b7062b86b88ad697682a5c00000000";
+
+    //noinspection SpellCheckingInspection
+    const SIGNED_BUYERS_REDIRECT_TX: &str = "\
+        0200000000010149634d8e127d370144fc943fd060f2af4067920ed11b10bc6e8e45102e1108ea0000000000fdffffff\
+        0388d2b8050000000022512039ee586be03c9d1cddbffc83e874f4b38212fd841fdfef2dcc94fb8b5abf32df5c8cd003\
+        00000000225120bdfe7695e32dfa072d8e561951925f3aff300d953cee127884b428de6b63d68c4a0100000000000022\
+        5120e47961ba4f26beb5d179e98fab691d8109f894e58a8127188b1944e7541571740140bac65d0b8207957f434a80a0\
+        ac02a21d9dfcd958b1ea804c44bad712e5728d9916c8bd91f386825638e750aaddacc734f9c724768aa4dbd9e8b87064\
+        a9cac9bd00000000";
+
+    #[expect(edition_2024_expr_fragment_specifier, reason = "for tests only; unlikely to break")]
+    macro_rules! tx {
+        ($hex:expr) => {{
+            let raw_tx = hex!($hex);
+            Transaction::consensus_decode(&mut raw_tx.as_slice()).unwrap()
+        }};
+    }
+
+    //noinspection SpellCheckingInspection
+    #[test]
+    fn test_warning_tx_builder() -> Result<()> {
+        let deposit_tx = tx!(SIGNED_DEPOSIT_TX);
+        let warning_tx = tx!(SIGNED_SELLERS_WARNING_TX);
+        let redirect_tx = tx!(SIGNED_BUYERS_REDIRECT_TX);
+
+        let [deposit_txid, warning_txid, redirect_txid] = [&deposit_tx, &warning_tx, &redirect_tx]
+            .map(Transaction::compute_txid);
+
+        assert_eq!("ea824fbd25dfaf768d2a4d2de11090063fb79b4950b1bc4f5f47aabe9d929040", deposit_txid.to_string());
+        assert_eq!("ea08112e10458e6ebc101bd10e926740aff260d03f94fc4401377d128e4d6349", warning_txid.to_string());
+        assert_eq!("8f0901c700f1692d56cdd0e059b822d0ee5e983fc5897f69eba3592a4728ba30", redirect_txid.to_string());
+
+        let buyer_payout_address = "bcrt1pnjz3ujass2z4cv9pgs28pat7mvkw20m5gfh3f4n5ul0qh0x3lkes0qv0uf"
+            .parse::<Address<_>>()?.require_network(Network::Regtest)?;
+        let seller_payout_address = "bcrt1p2gatkd99lxdhrcjxrvgeh8rqva9g9gj6lx42nf7uul8v77dxytmq0wnpk6"
+            .parse::<Address<_>>()?.require_network(Network::Regtest)?;
+
+        let buyer_input = TxOutput(OutPoint::new(deposit_txid, 3), TxOut {
+            value: Amount::from_sat(140_000_000),
+            script_pubkey: buyer_payout_address.script_pubkey(),
+        });
+        let seller_input = TxOutput(OutPoint::new(deposit_txid, 1), TxOut {
+            value: Amount::from_sat(20_000_000),
+            script_pubkey: seller_payout_address.script_pubkey(),
+        });
+
+        let escrow_address = "bcrt1pnjz3ujass2z4cv9pgs28pat7mvkw20m5gfh3f4n5ul0qh0x3lkes0qv0uf"
+            .parse::<Address<_>>()?.require_network(Network::Regtest)?;
+        let anchor_address = "bcrt1plvx2lxgvxv272s97l9qpagdltsp9020ur0p3mr45cm362q392vhqsq6rfa"
+            .parse::<Address<_>>()?.require_network(Network::Regtest)?;
+
+        let mut builder = WarningTxBuilder::default();
+        builder
+            .set_buyer_input(buyer_input)
+            .set_seller_input(seller_input)
+            .set_escrow_address(escrow_address)
+            .set_anchor_address(anchor_address)
+            .set_warning_lock_time(LockTime::from_height(2))
+            .set_fee_rate(FeeRate::from_sat_per_kwu(1182)) // gives 1000-sat absolute fee
+            .compute_unsigned_tx()?;
+
+        let unsigned_tx = builder.unsigned_tx()?;
+        let sighashes = [builder.buyer_input_sighash()?, builder.seller_input_sighash()?];
+
+        assert_eq!(warning_txid, unsigned_tx.compute_txid());
+        // TODO: Check that the sighashes are correct.
+        dbg!(sighashes);
+        Ok(())
+    }
 }

--- a/rpc/src/transaction.rs
+++ b/rpc/src/transaction.rs
@@ -1,0 +1,26 @@
+use bdk_wallet::bitcoin::opcodes::all::{OP_CHECKSIG, OP_CSV, OP_DROP};
+use bdk_wallet::bitcoin::taproot::TaprootBuilder;
+use bdk_wallet::bitcoin::{relative, script, ScriptBuf, TapNodeHash, XOnlyPublicKey};
+use relative::LockTime;
+
+pub const REGTEST_CLAIM_LOCK_TIME: LockTime = LockTime::from_height(5);
+
+fn claim_script(pub_key: &XOnlyPublicKey, lock_time: LockTime) -> ScriptBuf {
+    script::Builder::new()
+        .push_sequence(lock_time.to_sequence())
+        .push_opcode(OP_CSV)
+        .push_opcode(OP_DROP)
+        .push_x_only_key(pub_key)
+        .push_opcode(OP_CHECKSIG)
+        .into_script()
+}
+
+pub fn warning_output_merkle_root(claim_pub_key: &XOnlyPublicKey, claim_lock_time: LockTime) -> TapNodeHash {
+    let claim_script = claim_script(claim_pub_key, claim_lock_time);
+    TaprootBuilder::with_capacity(1)
+        .add_leaf(0, claim_script)
+        .expect("hardcoded TapTree build sequence should be valid")
+        .try_into_taptree()
+        .expect("hardcoded TapTree build sequence should be complete")
+        .root_hash()
+}


### PR DESCRIPTION
Add dedicated tx builders for the mock trade protocol implementation in the `rpc` package (exposed by the `Musig` gRPC service defined in `rpc.proto`), so that real sighashes can be used, instead of just signing hard-coded dummy messages. The payout & anchor addresses are still mocked and hard-coded, as well as the entire Deposit Tx construction, as there is no actual wallet integration at present (and some more thought needs to be put into tx fee handling when merging the buyer+seller input lists and their optional change outputs).

Also update the `Musig` service proto scheme to exchange missing Claim Tx payout addresses, nonces & partial signatures, to build a pair of prepared Claim Txs. And accept an optional trade-fee receiver (address + amount) from the client, to use as an extra output of the Deposit Tx. Also add checks that the _redirection_ receiver amounts sum to the correct total, logging warnings/errors if they don't (but not otherwise failing the trade), and add code+comments to `TradeProtocolClient.java` to illustrate how to properly use the updated API. Take care to modify the gRPC service in a way that won't break the Bisq2 client, though, to give it a chance to stay in sync.

Finally, make sure that all the multisig pubkeys are tweaked, with suitably distinct tap-tweaks, to address the security concerns raised in the comments of #75. In particular, the payout pubkeys/addresses must be distinct from the Warning escrow pubkeys/addresses, so need to be given different tweaks. This can be neatly achieved by providing a script-spend path for each warning escrow output (giving each a non-null merkle root), but making the Deposit outputs keyspend only. To this end, add a _Claim_ script-spend path using `OP_CHECKSEQUENCEVERIFY` to each Warning escrow output, which serves as a backup to the (keyspend-only) prepared Claim Txs, in case of fee volatility (or just for extra payout flexibility).

--

TODO: Consider moving the builders into the `protocol` crate and use them for the implementation there, to help keep the tx construction and wallet interface logic separate from each other and from the crypto, for better modularity and testability. This could be done in a separate PR.
