### PR TITLE
feat: add empty wallet service

### DIFF
--- a/rpc/build.rs
+++ b/rpc/build.rs
@@ -73,7 +73,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // Now compile all the protos...
         .compile_protos(
-            &["src/main/proto/rpc.proto", "src/main/proto/wallet.proto", "src/main/proto/bmp_protocol.proto"],
+            &["src/main/proto/rpc.proto", "src/main/proto/wallet.proto", "src/main/proto/bmp_protocol.proto", "src/main/proto/bmp_wallet.proto"],
             &["src/main/proto"],
         )?;
     Ok(())

--- a/rpc/build.rs
+++ b/rpc/build.rs
@@ -73,7 +73,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // Now compile all the protos...
         .compile_protos(
-            &["src/main/proto/rpc.proto", "src/main/proto/wallet.proto", "src/main/proto/bmp_protocol.proto", "src/main/proto/bmp_wallet.proto"],
+            &[
+                "src/main/proto/rpc.proto",
+                "src/main/proto/wallet.proto",
+                "src/main/proto/bmp_protocol.proto",
+                "src/main/proto/bmp_wallet.proto",
+            ],
             &["src/main/proto"],
         )?;
     Ok(())

--- a/rpc/src/bin/musigd.rs
+++ b/rpc/src/bin/musigd.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 use rpc::bmp_service::BmpServiceImpl;
+use rpc::bmp_wallet_service::BmpWalletServiceImpl;
 use rpc::pb::bmp_protocol::bmp_protocol_service_server::BmpProtocolServiceServer;
+use rpc::pb::bmp_wallet::wallet_server::WalletServer as BmpWalletServer;
 use rpc::server::{MusigImpl, MusigServer, WalletImpl, WalletServer};
 use rpc::wallet::WalletServiceImpl;
 use std::error::Error;
@@ -12,8 +14,6 @@ use tracing_subscriber::filter::{EnvFilter, ParseError};
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
-use rpc::bmp_wallet_service::BmpWalletServiceImpl;
-use rpc::pb::bmp_wallet::wallet_server::WalletServer as BmpWalletServer;
 
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]

--- a/rpc/src/bin/musigd.rs
+++ b/rpc/src/bin/musigd.rs
@@ -12,6 +12,8 @@ use tracing_subscriber::filter::{EnvFilter, ParseError};
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
+use rpc::bmp_wallet_service::BmpWalletServiceImpl;
+use rpc::pb::bmp_wallet::wallet_server::WalletServer as BmpWalletServer;
 
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
@@ -46,12 +48,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     wallet.wallet_service.clone().spawn_connection();
 
     let bmp_protocol_impl = BmpServiceImpl::default();
+    let bmp_wallet_service = BmpWalletServiceImpl::default();
 
     info!(port = cli.port, "Starting gRPC server.");
     Server::builder()
         .add_service(MusigServer::new(musig))
         .add_service(WalletServer::new(wallet))
         .add_service(BmpProtocolServiceServer::new(bmp_protocol_impl))
+        .add_service(BmpWalletServer::new(bmp_wallet_service))
         .serve(addr)
         .await?;
 

--- a/rpc/src/bmp_wallet_service.rs
+++ b/rpc/src/bmp_wallet_service.rs
@@ -1,0 +1,143 @@
+use crate::pb::bmp_wallet;
+use crate::pb::bmp_wallet::wallet_server::Wallet;
+use tonic::{Request, Response, Status};
+use tracing::info;
+
+#[derive(Debug, Default)]
+pub struct BmpWalletServiceImpl {}
+
+#[tonic::async_trait]
+impl Wallet for BmpWalletServiceImpl {
+    async fn is_wallet_ready(
+        &self,
+        _request: Request<bmp_wallet::IsWalletReadyRequest>,
+    ) -> Result<Response<bmp_wallet::IsWalletReadyResponse>, Status> {
+        info!("is_wallet_ready called");
+        Ok(Response::new(bmp_wallet::IsWalletReadyResponse { ready: true }))
+    }
+
+    async fn get_unused_address(
+        &self,
+        _request: Request<bmp_wallet::GetUnusedAddressRequest>,
+    ) -> Result<Response<bmp_wallet::GetUnusedAddressResponse>, Status> {
+        info!("get_unused_address called");
+        Ok(Response::new(bmp_wallet::GetUnusedAddressResponse {
+            address: "bc1qvyw2m3f2y2p2l42jm2q5j2j2q2j2q2j2q2j2q2".to_string(),
+        }))
+    }
+
+    async fn get_wallet_addresses(
+        &self,
+        _request: Request<bmp_wallet::GetWalletAddressesRequest>,
+    ) -> Result<Response<bmp_wallet::GetWalletAddressesResponse>, Status> {
+        info!("get_wallet_addresses called");
+        Ok(Response::new(bmp_wallet::GetWalletAddressesResponse {
+            addresses: vec![
+                "bc1qvyw2m3f2y2p2l42jm2q5j2j2q2j2q2j2q2j2q2".to_string(),
+                "bc1qvyw2m3f2y2p2l42jm2q5j2j2q2j2q2j2q2j2q3".to_string(),
+            ],
+        }))
+    }
+
+    async fn list_transactions(
+        &self,
+        _request: Request<bmp_wallet::ListTransactionsRequest>,
+    ) -> Result<Response<bmp_wallet::ListTransactionsResponse>, Status> {
+        info!("list_transactions called");
+        let transactions = vec![bmp_wallet::Transaction {
+            tx_id: "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16".to_string(),
+            inputs: vec![],
+            outputs: vec![],
+            lock_time: 0,
+            height: 123456,
+            date: 1678886400,
+            confirmations: 10,
+            amount: 100000,
+            incoming: true,
+        }];
+        Ok(Response::new(bmp_wallet::ListTransactionsResponse {
+            transactions,
+        }))
+    }
+
+    async fn list_utxos(
+        &self,
+        _request: Request<bmp_wallet::ListUtxosRequest>,
+    ) -> Result<Response<bmp_wallet::ListUtxosResponse>, Status> {
+        info!("list_utxos called");
+        let utxos = vec![bmp_wallet::Utxo {
+            tx_id: "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16".to_string(),
+            vout: 0,
+            amount: 100000,
+            address: "bc1qvyw2m3f2y2p2l42jm2q5j2j2q2j2q2j2q2j2q2".to_string(),
+            confirmations: 10,
+        }];
+        Ok(Response::new(bmp_wallet::ListUtxosResponse { utxos }))
+    }
+
+    async fn send_to_address(
+        &self,
+        _request: Request<bmp_wallet::SendToAddressRequest>,
+    ) -> Result<Response<bmp_wallet::SendToAddressResponse>, Status> {
+        info!("send_to_address called");
+        Ok(Response::new(bmp_wallet::SendToAddressResponse {
+            tx_id: "e40a1b5b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b".to_string(),
+        }))
+    }
+
+    async fn is_wallet_encrypted(
+        &self,
+        _request: Request<bmp_wallet::IsWalletEncryptedRequest>,
+    ) -> Result<Response<bmp_wallet::IsWalletEncryptedResponse>, Status> {
+        info!("is_wallet_encrypted called");
+        Ok(Response::new(bmp_wallet::IsWalletEncryptedResponse {
+            encrypted: true,
+        }))
+    }
+
+    async fn get_balance(
+        &self,
+        _request: Request<bmp_wallet::GetBalanceRequest>,
+    ) -> Result<Response<bmp_wallet::GetBalanceResponse>, Status> {
+        info!("get_balance called");
+        Ok(Response::new(bmp_wallet::GetBalanceResponse { balance: 123456789 }))
+    }
+
+    async fn get_seed_words(
+        &self,
+        _request: Request<bmp_wallet::GetSeedWordsRequest>,
+    ) -> Result<Response<bmp_wallet::GetSeedWordsResponse>, Status> {
+        info!("get_seed_words called");
+        let seed_words = vec![
+            "abandon".to_string(),
+            "ability".to_string(),
+            "able".to_string(),
+            "about".to_string(),
+            "above".to_string(),
+            "absent".to_string(),
+            "absorb".to_string(),
+            "abstract".to_string(),
+            "absurd".to_string(),
+            "abuse".to_string(),
+            "access".to_string(),
+            "accident".to_string(),
+        ];
+        Ok(Response::new(bmp_wallet::GetSeedWordsResponse { seed_words }))
+    }
+
+    async fn encrypt_wallet(
+        &self,
+        _request: Request<bmp_wallet::EncryptWalletRequest>,
+    ) -> Result<Response<bmp_wallet::EncryptWalletResponse>, Status> {
+        info!("encrypt_wallet called");
+        Ok(Response::new(bmp_wallet::EncryptWalletResponse { success: true }))
+    }
+
+    async fn decrypt_wallet(
+        &self,
+        _request: Request<bmp_wallet::DecryptWalletRequest>,
+    ) -> Result<Response<bmp_wallet::DecryptWalletResponse>, Status> {
+        info!("decrypt_wallet called");
+        Ok(Response::new(bmp_wallet::DecryptWalletResponse { success: true }))
+    }
+}

--- a/rpc/src/bmp_wallet_service.rs
+++ b/rpc/src/bmp_wallet_service.rs
@@ -49,9 +49,9 @@ impl Wallet for BmpWalletServiceImpl {
             inputs: vec![],
             outputs: vec![],
             lock_time: 0,
-            height: 123456,
+            block_height: 123456,
             date: 1678886400,
-            confirmations: 10,
+            num_confirmations: 10,
             amount: 100000,
             incoming: true,
         }];
@@ -70,7 +70,7 @@ impl Wallet for BmpWalletServiceImpl {
             vout: 0,
             amount: 100000,
             address: "bc1qvyw2m3f2y2p2l42jm2q5j2j2q2j2q2j2q2j2q2".to_string(),
-            confirmations: 10,
+            num_confirmations: 10,
         }];
         Ok(Response::new(bmp_wallet::ListUtxosResponse { utxos }))
     }

--- a/rpc/src/bmp_wallet_service.rs
+++ b/rpc/src/bmp_wallet_service.rs
@@ -1,6 +1,6 @@
 use crate::pb::bmp_wallet;
 use crate::pb::bmp_wallet::wallet_server::Wallet;
-use tonic::{Request, Response, Status};
+use tonic::{Request, Response, Result};
 use tracing::info;
 
 #[derive(Debug, Default)]
@@ -11,30 +11,32 @@ impl Wallet for BmpWalletServiceImpl {
     async fn is_wallet_ready(
         &self,
         _request: Request<bmp_wallet::IsWalletReadyRequest>,
-    ) -> Result<Response<bmp_wallet::IsWalletReadyResponse>, Status> {
+    ) -> Result<Response<bmp_wallet::IsWalletReadyResponse>> {
         info!("is_wallet_ready called");
-        Ok(Response::new(bmp_wallet::IsWalletReadyResponse { ready: true }))
+        Ok(Response::new(bmp_wallet::IsWalletReadyResponse {
+            ready: true,
+        }))
     }
 
     async fn get_unused_address(
         &self,
         _request: Request<bmp_wallet::GetUnusedAddressRequest>,
-    ) -> Result<Response<bmp_wallet::GetUnusedAddressResponse>, Status> {
+    ) -> Result<Response<bmp_wallet::GetUnusedAddressResponse>> {
         info!("get_unused_address called");
         Ok(Response::new(bmp_wallet::GetUnusedAddressResponse {
-            address: "bc1qvyw2m3f2y2p2l42jm2q5j2j2q2j2q2j2q2j2q2".to_string(),
+            address: "bc1qvyw2m3f2y2p2l42jm2q5j2j2q2j2q2j2q2j2q2".to_owned(),
         }))
     }
 
     async fn get_wallet_addresses(
         &self,
         _request: Request<bmp_wallet::GetWalletAddressesRequest>,
-    ) -> Result<Response<bmp_wallet::GetWalletAddressesResponse>, Status> {
+    ) -> Result<Response<bmp_wallet::GetWalletAddressesResponse>> {
         info!("get_wallet_addresses called");
         Ok(Response::new(bmp_wallet::GetWalletAddressesResponse {
             addresses: vec![
-                "bc1qvyw2m3f2y2p2l42jm2q5j2j2q2j2q2j2q2j2q2".to_string(),
-                "bc1qvyw2m3f2y2p2l42jm2q5j2j2q2j2q2j2q2j2q3".to_string(),
+                "bc1qvyw2m3f2y2p2l42jm2q5j2j2q2j2q2j2q2j2q2".to_owned(),
+                "bc1qvyw2m3f2y2p2l42jm2q5j2j2q2j2q2j2q2j2q3".to_owned(),
             ],
         }))
     }
@@ -42,17 +44,17 @@ impl Wallet for BmpWalletServiceImpl {
     async fn list_transactions(
         &self,
         _request: Request<bmp_wallet::ListTransactionsRequest>,
-    ) -> Result<Response<bmp_wallet::ListTransactionsResponse>, Status> {
+    ) -> Result<Response<bmp_wallet::ListTransactionsResponse>> {
         info!("list_transactions called");
         let transactions = vec![bmp_wallet::Transaction {
-            tx_id: "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16".to_string(),
+            tx_id: "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16".to_owned(),
             inputs: vec![],
             outputs: vec![],
             lock_time: 0,
-            block_height: 123456,
-            date: 1678886400,
+            block_height: 123_456,
+            date: 1_678_886_400,
             num_confirmations: 10,
-            amount: 100000,
+            amount: 100_000,
             incoming: true,
         }];
         Ok(Response::new(bmp_wallet::ListTransactionsResponse {
@@ -63,13 +65,13 @@ impl Wallet for BmpWalletServiceImpl {
     async fn list_utxos(
         &self,
         _request: Request<bmp_wallet::ListUtxosRequest>,
-    ) -> Result<Response<bmp_wallet::ListUtxosResponse>, Status> {
+    ) -> Result<Response<bmp_wallet::ListUtxosResponse>> {
         info!("list_utxos called");
         let utxos = vec![bmp_wallet::Utxo {
-            tx_id: "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16".to_string(),
+            tx_id: "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16".to_owned(),
             vout: 0,
-            amount: 100000,
-            address: "bc1qvyw2m3f2y2p2l42jm2q5j2j2q2j2q2j2q2j2q2".to_string(),
+            amount: 100_000,
+            address: "bc1qvyw2m3f2y2p2l42jm2q5j2j2q2j2q2j2q2j2q2".to_owned(),
             num_confirmations: 10,
         }];
         Ok(Response::new(bmp_wallet::ListUtxosResponse { utxos }))
@@ -78,17 +80,17 @@ impl Wallet for BmpWalletServiceImpl {
     async fn send_to_address(
         &self,
         _request: Request<bmp_wallet::SendToAddressRequest>,
-    ) -> Result<Response<bmp_wallet::SendToAddressResponse>, Status> {
+    ) -> Result<Response<bmp_wallet::SendToAddressResponse>> {
         info!("send_to_address called");
         Ok(Response::new(bmp_wallet::SendToAddressResponse {
-            tx_id: "e40a1b5b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b".to_string(),
+            tx_id: "e40a1b5b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b1a1b".to_owned(),
         }))
     }
 
     async fn is_wallet_encrypted(
         &self,
         _request: Request<bmp_wallet::IsWalletEncryptedRequest>,
-    ) -> Result<Response<bmp_wallet::IsWalletEncryptedResponse>, Status> {
+    ) -> Result<Response<bmp_wallet::IsWalletEncryptedResponse>> {
         info!("is_wallet_encrypted called");
         Ok(Response::new(bmp_wallet::IsWalletEncryptedResponse {
             encrypted: true,
@@ -98,46 +100,45 @@ impl Wallet for BmpWalletServiceImpl {
     async fn get_balance(
         &self,
         _request: Request<bmp_wallet::GetBalanceRequest>,
-    ) -> Result<Response<bmp_wallet::GetBalanceResponse>, Status> {
+    ) -> Result<Response<bmp_wallet::GetBalanceResponse>> {
         info!("get_balance called");
-        Ok(Response::new(bmp_wallet::GetBalanceResponse { balance: 123456789 }))
+        Ok(Response::new(bmp_wallet::GetBalanceResponse {
+            balance: 123_456_789,
+        }))
     }
 
     async fn get_seed_words(
         &self,
         _request: Request<bmp_wallet::GetSeedWordsRequest>,
-    ) -> Result<Response<bmp_wallet::GetSeedWordsResponse>, Status> {
+    ) -> Result<Response<bmp_wallet::GetSeedWordsResponse>> {
         info!("get_seed_words called");
-        let seed_words = vec![
-            "abandon".to_string(),
-            "ability".to_string(),
-            "able".to_string(),
-            "about".to_string(),
-            "above".to_string(),
-            "absent".to_string(),
-            "absorb".to_string(),
-            "abstract".to_string(),
-            "absurd".to_string(),
-            "abuse".to_string(),
-            "access".to_string(),
-            "accident".to_string(),
-        ];
-        Ok(Response::new(bmp_wallet::GetSeedWordsResponse { seed_words }))
+        let seed_words =
+            "abandon ability able about above absent absorb abstract absurd abuse access accident"
+                .split_ascii_whitespace()
+                .map(str::to_owned)
+                .collect::<Vec<String>>();
+        Ok(Response::new(bmp_wallet::GetSeedWordsResponse {
+            seed_words,
+        }))
     }
 
     async fn encrypt_wallet(
         &self,
         _request: Request<bmp_wallet::EncryptWalletRequest>,
-    ) -> Result<Response<bmp_wallet::EncryptWalletResponse>, Status> {
+    ) -> Result<Response<bmp_wallet::EncryptWalletResponse>> {
         info!("encrypt_wallet called");
-        Ok(Response::new(bmp_wallet::EncryptWalletResponse { success: true }))
+        Ok(Response::new(bmp_wallet::EncryptWalletResponse {
+            success: true,
+        }))
     }
 
     async fn decrypt_wallet(
         &self,
         _request: Request<bmp_wallet::DecryptWalletRequest>,
-    ) -> Result<Response<bmp_wallet::DecryptWalletResponse>, Status> {
+    ) -> Result<Response<bmp_wallet::DecryptWalletResponse>> {
         info!("decrypt_wallet called");
-        Ok(Response::new(bmp_wallet::DecryptWalletResponse { success: true }))
+        Ok(Response::new(bmp_wallet::DecryptWalletResponse {
+            success: true,
+        }))
     }
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -4,9 +4,11 @@ pub mod pb {
     pub mod convert;
     pub mod musigrpc;
     pub mod walletrpc;
+    pub mod bmp_wallet;
 }
 
 pub mod bmp_service;
+pub mod bmp_wallet_service;
 mod observable;
 mod protocol;
 pub mod server;

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,10 +1,10 @@
 pub mod pb {
     pub mod bmp_converter;
     pub mod bmp_protocol;
+    pub mod bmp_wallet;
     pub mod convert;
     pub mod musigrpc;
     pub mod walletrpc;
-    pub mod bmp_wallet;
 }
 
 pub mod bmp_service;

--- a/rpc/src/main/proto/bmp_wallet.proto
+++ b/rpc/src/main/proto/bmp_wallet.proto
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 syntax = "proto3";
 
 package wallet;
@@ -99,8 +116,8 @@ message DecryptWalletResponse {
 
 message TransactionInput {
     string prevOutTxId = 1;
-    int32 prevOutIndex = 2;
-    int64 sequenceNumber = 3;
+    sint32 prevOutIndex = 2;
+    sint64 sequenceNumber = 3;
     string scriptSig = 4;
     string witness = 5;
 }
@@ -115,18 +132,18 @@ message Transaction {
     string txId = 1;
     repeated TransactionInput inputs = 2;
     repeated TransactionOutput outputs = 3;
-    int32 lockTime = 4;
-    int32 height = 5;
-    int64 date = 6; // Unix timestamp
-    int32 confirmations = 7;
+    sint64 lockTime = 4;
+    sint32 blockHeight = 5;
+    sint64 date = 6; // Unix timestamp
+    sint32 numConfirmations = 7;
     sint64 amount = 8;
     bool incoming = 9;
 }
 
 message Utxo {
     string txId = 1;
-    int32 vout = 2;
+    sint32 vout = 2;
     sint64 amount = 3;
     string address = 4;
-    int32 confirmations = 5;
+    sint32 numConfirmations = 5;
 }

--- a/rpc/src/main/proto/bmp_wallet.proto
+++ b/rpc/src/main/proto/bmp_wallet.proto
@@ -1,0 +1,132 @@
+syntax = "proto3";
+
+package wallet;
+
+option java_multiple_files = true;
+option java_package = "bisq.wallet.protobuf";
+
+// The WalletService definition.
+service Wallet {
+    rpc IsWalletReady (IsWalletReadyRequest) returns (IsWalletReadyResponse);
+    rpc GetUnusedAddress (GetUnusedAddressRequest) returns (GetUnusedAddressResponse);
+    rpc GetWalletAddresses (GetWalletAddressesRequest) returns (GetWalletAddressesResponse);
+    rpc ListTransactions (ListTransactionsRequest) returns (ListTransactionsResponse);
+    rpc ListUtxos (ListUtxosRequest) returns (ListUtxosResponse);
+    rpc SendToAddress (SendToAddressRequest) returns (SendToAddressResponse);
+    rpc IsWalletEncrypted (IsWalletEncryptedRequest) returns (IsWalletEncryptedResponse);
+    rpc GetBalance (GetBalanceRequest) returns (GetBalanceResponse);
+    rpc GetSeedWords (GetSeedWordsRequest) returns (GetSeedWordsResponse);
+    rpc EncryptWallet (EncryptWalletRequest) returns (EncryptWalletResponse);
+    rpc DecryptWallet (DecryptWalletRequest) returns (DecryptWalletResponse);
+}
+
+
+
+message IsWalletReadyRequest {}
+
+message IsWalletReadyResponse {
+    bool ready = 1;
+}
+
+message GetUnusedAddressRequest {}
+
+message GetUnusedAddressResponse {
+    string address = 1;
+}
+
+message GetWalletAddressesRequest {}
+
+message GetWalletAddressesResponse {
+    repeated string addresses = 1;
+}
+
+message ListTransactionsRequest {}
+
+message ListTransactionsResponse {
+    repeated Transaction transactions = 1;
+}
+
+message ListUtxosRequest {}
+
+message ListUtxosResponse {
+    repeated Utxo utxos = 1;
+}
+
+message SendToAddressRequest {
+    optional string passphrase = 1;
+    string address = 2;
+    sint64 amount = 3;
+}
+
+message SendToAddressResponse {
+    string txId = 1;
+}
+
+message IsWalletEncryptedRequest {}
+
+message IsWalletEncryptedResponse {
+    bool encrypted = 1;
+}
+
+message GetBalanceRequest {}
+
+message GetBalanceResponse {
+    // Balance in satoshis
+    sint64 balance = 1;
+}
+
+message GetSeedWordsRequest {}
+
+message GetSeedWordsResponse {
+    repeated string seedWords = 1;
+}
+
+message EncryptWalletRequest {
+    string password = 1;
+}
+
+message EncryptWalletResponse {
+    bool success = 1;
+}
+
+message DecryptWalletRequest {
+    string password = 1;
+}
+
+message DecryptWalletResponse {
+    bool success = 1;
+}
+
+message TransactionInput {
+    string prevOutTxId = 1;
+    int32 prevOutIndex = 2;
+    int64 sequenceNumber = 3;
+    string scriptSig = 4;
+    string witness = 5;
+}
+
+message TransactionOutput {
+    sint64 value = 1;
+    string address = 2;
+    string scriptPubKey = 3;
+}
+
+message Transaction {
+    string txId = 1;
+    repeated TransactionInput inputs = 2;
+    repeated TransactionOutput outputs = 3;
+    int32 lockTime = 4;
+    int32 height = 5;
+    int64 date = 6; // Unix timestamp
+    int32 confirmations = 7;
+    sint64 amount = 8;
+    bool incoming = 9;
+}
+
+message Utxo {
+    string txId = 1;
+    int32 vout = 2;
+    sint64 amount = 3;
+    string address = 4;
+    int32 confirmations = 5;
+}

--- a/rpc/src/main/proto/bmp_wallet.proto
+++ b/rpc/src/main/proto/bmp_wallet.proto
@@ -118,14 +118,14 @@ message TransactionInput {
     string prevOutTxId = 1;
     sint32 prevOutIndex = 2;
     sint64 sequenceNumber = 3;
-    string scriptSig = 4;
+    bytes scriptSig = 4;
     string witness = 5;
 }
 
 message TransactionOutput {
     sint64 value = 1;
     string address = 2;
-    string scriptPubKey = 3;
+    bytes scriptPubKey = 3;
 }
 
 message Transaction {

--- a/rpc/src/pb/bmp_wallet.rs
+++ b/rpc/src/pb/bmp_wallet.rs
@@ -1,0 +1,2 @@
+#![allow(clippy::all, clippy::pedantic, clippy::restriction, clippy::nursery)]
+tonic::include_proto!("wallet");


### PR DESCRIPTION
Added a skeleton of the wallet gRPC service:
- The bmp_wallet.proto file defining the service(refer to: https://github.com/bisq-network/bisq2/pull/3728 ).
- An implementation of the service in BmpWalletServiceImpl that returns dummy data for testing.
- Integration of the new service into the musigd.
