### PR TITLE
Add Deposit PSBT merging/shuffling & signatures to tx builders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "block-buffer"
@@ -413,7 +413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata 0.4.10",
  "serde",
 ]
 
@@ -437,18 +437,18 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chrono"
@@ -806,7 +806,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -928,13 +928,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -942,6 +943,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1024,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -1035,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1274,9 +1276,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
@@ -1285,7 +1287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
 ]
 
 [[package]]
@@ -1387,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1397,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.97"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -1586,14 +1588,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata 0.4.10",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -1607,13 +1609,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -1624,9 +1626,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "ring"
@@ -1660,6 +1662,7 @@ dependencies = [
  "prost",
  "protocol",
  "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rpc",
  "serde",
  "serde_with",
@@ -1840,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
@@ -1860,7 +1863,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -1944,9 +1947,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1961,15 +1964,15 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1980,18 +1983,18 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "2.0.14"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.14"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2167,7 +2170,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ bdk_electrum = { version = "0.23.1", default-features = false, features = ["use-
 bdk_wallet = "2.1.0"
 musig2 = { version = "0.3.1", features = ["rand"] }
 rand = "0.9.2"
+rand_chacha = "0.9.0"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -15,9 +15,10 @@ paste = "1.0.15"
 prost = "0.14.1"
 protocol = { path = "../protocol" }
 rand = { workspace = true }
+rand_chacha = { workspace = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_with = { version = "3.14.0", features = ["base64", "hex"] }
-thiserror = "2.0.14"
+thiserror = "2.0.16"
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "time"] }
 tokio-stream = "0.1.17"
 tonic = "0.14.1"

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -9,7 +9,9 @@ pub mod pb {
 pub mod bmp_service;
 mod observable;
 mod protocol;
+mod psbt;
 pub mod server;
 mod storage;
+mod swap;
 mod transaction;
 pub mod wallet;

--- a/rpc/src/psbt.rs
+++ b/rpc/src/psbt.rs
@@ -1,0 +1,230 @@
+use bdk_wallet::bitcoin::amount::CheckedSum as _;
+use bdk_wallet::bitcoin::hashes::Hash as _;
+use bdk_wallet::bitcoin::opcodes::all::OP_RETURN;
+use bdk_wallet::bitcoin::transaction::Version;
+use bdk_wallet::bitcoin::{
+    absolute, script, Address, Amount, FeeRate, Network, Psbt, ScriptBuf, Sequence, Transaction,
+    TxIn, TxOut, Weight,
+};
+use rand::{RngCore, SeedableRng as _};
+use rand_chacha::ChaCha20Rng;
+use std::mem;
+
+use crate::swap::Swap as _;
+use crate::transaction::{Receiver, Result, TransactionErrorKind, TxOutput};
+
+// The outputs of each trader's half-deposit PSBT consists of a temporary OP_RETURN placeholder with
+// a 27-byte random datagram, burning their trade deposit, followed by any fee receivers(s) in the
+// case of the seller (who the Rust side shall deem responsible for paying the trade fees), followed
+// by optional change output(s).
+//
+// A 27-byte-length datagram is chosen to make the estimated weights of the signed half-deposit
+// PSBTs sum to 2 wu more than the final signed deposit tx weight. (Attaining an exact match is not
+// possible, due to the 4 wu granularity of non-witness part of the tx.)
+//
+// When the half-PSBTs are merged, the placeholders are replaced with the actual payout UTXOs. The
+// injected randomness of the (trade-private) OP_RETURN datagrams ensures that a _deterministic_
+// shuffling of the merged deposit PSBT inputs & outputs is unpredictable to any 3rd party.
+pub fn half_deposit_placeholder_spk(rng: &mut impl RngCore) -> ScriptBuf {
+    let mut data = [0u8; 27];
+    rng.fill_bytes(&mut data);
+    script::Builder::new()
+        .push_opcode(OP_RETURN)
+        .push_slice(data)
+        .into_script()
+}
+
+fn half_deposit_tx_weight(num_keyspend_inputs: u16, num_p2tr_change_outputs: u16) -> Weight {
+    const HALF_DEPOSIT_TX_BASE_WEIGHT: Weight = Weight::from_wu(193);
+    const KEYSPEND_INPUT_WEIGHT: Weight = Weight::from_wu(230); // Assumes default sighash type
+    const P2TR_OUTPUT_WEIGHT: Weight = Weight::from_wu(172);
+
+    HALF_DEPOSIT_TX_BASE_WEIGHT
+        + KEYSPEND_INPUT_WEIGHT * u64::from(num_keyspend_inputs)
+        + P2TR_OUTPUT_WEIGHT * u64::from(num_p2tr_change_outputs)
+}
+
+//noinspection SpellCheckingInspection
+pub(crate) fn mock_buyer_half_deposit_psbt(
+    deposit_amount: Amount,
+    fee_rate: FeeRate,
+    rng: &mut impl RngCore,
+) -> Option<Psbt> {
+    let weight = half_deposit_tx_weight(1, 1);
+
+    let change_amount = Amount::from_sat(100_000_000)
+        .checked_sub(deposit_amount)?
+        .checked_sub(fee_rate.checked_mul_by_weight(weight)?)?;
+    let change_address = "bcrt1pgsj9aw0wvs5h6zj780djnu267v6jazmfekwm4g4q4s6ax3w3t0lseqqnjc"
+        .parse::<Address<_>>().ok()?.require_network(Network::Regtest).ok()?;
+
+    let unsigned_tx = Transaction {
+        version: Version::TWO,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![
+            TxIn {
+                previous_output: "658654575bbbeb46e965bd9eb37fd3be550a7e0fa2d64bc5f218763155602300:0".parse().ok()?,
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                ..TxIn::default()
+            },
+        ],
+        output: vec![
+            TxOut { value: deposit_amount, script_pubkey: half_deposit_placeholder_spk(rng) },
+            TxOut { value: change_amount, script_pubkey: change_address.script_pubkey() },
+        ],
+    };
+    Psbt::from_unsigned_tx(unsigned_tx).ok()
+}
+
+//noinspection SpellCheckingInspection
+pub(crate) fn mock_seller_half_deposit_psbt(
+    deposit_amount: Amount,
+    fee_rate: FeeRate,
+    trade_fee_receivers: &[Receiver],
+    rng: &mut impl RngCore,
+) -> Option<Psbt> {
+    let weight_excluding_receivers = half_deposit_tx_weight(2, 1);
+
+    // We assume a large `extra_output_num` of 128 here because the peer may have decided to add a
+    // large number of change outputs to his deposit tx half (for whatever reason), so budget half
+    // of the single-byte-compact-integer output count limit of 252 to each trader.
+    let total_fees_msat = Receiver::total_output_cost_msat(trade_fee_receivers, fee_rate, 128)?
+        .checked_add(fee_rate.to_sat_per_kwu().checked_mul(weight_excluding_receivers.to_wu())?)?;
+
+    let change_amount = Amount::from_sat(200_000_000)
+        .checked_sub(deposit_amount)?
+        .checked_sub(Amount::from_sat(total_fees_msat.checked_add(999)? / 1000))?;
+    let change_address = "bcrt1p80xu5f0nqjarfnechsmlt488jf3tykx8cva9zeeczlsu4c7x557qr499gz"
+        .parse::<Address<_>>().ok()?.require_network(Network::Regtest).ok()?;
+
+    let mut output = Vec::with_capacity(trade_fee_receivers.len() + 2);
+    output.push(TxOut { value: deposit_amount, script_pubkey: half_deposit_placeholder_spk(rng) });
+    output.extend(trade_fee_receivers.iter().map(TxOut::from));
+    output.push(TxOut { value: change_amount, script_pubkey: change_address.script_pubkey() });
+
+    let unsigned_tx = Transaction {
+        version: Version::TWO,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![
+            TxIn {
+                previous_output: "4a5ecc72ec8db78f11c6785f560a13f6f32eac66d160a8157d30956695ccf523:0".parse().ok()?,
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                ..TxIn::default()
+            },
+            TxIn {
+                previous_output: "373b3ca0b9135e9649672772d4659bb5597d06b4694f1fbdbece285823fde0a3:1".parse().ok()?,
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                ..TxIn::default()
+            },
+        ],
+        output,
+    };
+    Psbt::from_unsigned_tx(unsigned_tx).ok()
+}
+
+fn half_psbt_fee_overpay_msat(psbt: &Psbt, target_fee_rate: FeeRate) -> Option<i64> {
+    // Satisfaction weight of each input assuming default sighash type.
+    // FIXME: Don't just assume that all inputs are p2tr keyspends.
+    const KEYSPEND_WITNESS_WEIGHT: Weight = Weight::from_wu(66);
+
+    // This is the extra weight of witness vs non-witness consensus-serialization (2 wu) minus 1 wu
+    // to account for the fact that the base weight of a half-deposit PSBT is 194 wu, which is 1 wu
+    // more than half the base weight (386 wu) of the final deposit tx, so just pretend it's 193 wu.
+    const EXTRA_WEIGHT: Weight = Weight::from_wu(1);
+
+    let signed_tx_weight = psbt.unsigned_tx.weight() + EXTRA_WEIGHT
+        + KEYSPEND_WITNESS_WEIGHT * psbt.inputs.len() as u64;
+
+    // FIXME: Don't just assume that all inputs are 1 BTC each!
+    let input_amount = Amount::ONE_BTC * psbt.inputs.len() as u64;
+    let output_amount = psbt.unsigned_tx.output.iter().map(|o| o.value).checked_sum()?;
+
+    let actual_fee_msat = input_amount.checked_sub(output_amount)?.to_sat().checked_mul(1000)?;
+    let target_fee_msat = target_fee_rate.to_sat_per_kwu().checked_mul(signed_tx_weight.to_wu())?;
+
+    Some(i64::try_from(actual_fee_msat).ok()? - i64::try_from(target_fee_msat).ok()?)
+}
+
+pub fn merge_psbt_halves(buyer_psbt: &Psbt, seller_psbt: &Psbt, target_fee_rate: FeeRate, num_receivers: usize) -> Result<Psbt> {
+    fn re<T: Clone>(dest: &mut Vec<T>, src: &[T]) -> Vec<T> {
+        let mut cloned_src = Vec::with_capacity(src.len() + dest.len());
+        cloned_src.extend(src.iter().cloned());
+        mem::replace(dest, cloned_src)
+    }
+    use std::convert::identity as id;
+
+    // TODO: Need to do much more thorough half-PSBT validation than this:
+    if buyer_psbt.outputs.is_empty() || seller_psbt.outputs.is_empty() ||
+        buyer_psbt.inputs.len() != buyer_psbt.unsigned_tx.input.len() ||
+        buyer_psbt.outputs.len() != buyer_psbt.unsigned_tx.output.len() ||
+        seller_psbt.inputs.len() != seller_psbt.unsigned_tx.input.len() ||
+        seller_psbt.outputs.len() != seller_psbt.unsigned_tx.output.len() {
+        return Err(TransactionErrorKind::InvalidPsbt);
+    }
+
+    let buyer_overpay_msat = half_psbt_fee_overpay_msat(buyer_psbt, target_fee_rate)
+        .ok_or(TransactionErrorKind::Overflow)?;
+    let seller_overpay_msat = half_psbt_fee_overpay_msat(seller_psbt, target_fee_rate)
+        .ok_or(TransactionErrorKind::Overflow)?;
+    if buyer_overpay_msat.is_negative() || seller_overpay_msat.is_negative() {
+        return Err(TransactionErrorKind::InvalidPsbt);
+    }
+    #[expect(clippy::cast_sign_loss, reason = "already checked for negatives")]
+    let overpay_total_msat = buyer_overpay_msat as u64 + seller_overpay_msat as u64;
+    let buyer_has_change = buyer_psbt.outputs.len() > 1;
+    let seller_has_change = seller_psbt.outputs.len() > 1 + num_receivers;
+
+    // Because each PSBT half must pay tx fees rounded up to the next satoshi, the fee overpay of
+    // the merged deposit tx can exceed 1 sat, even when neither half is overpaying. In that case,
+    // give the extra 1 sat to whoever suffered the greater rounding error. Don't redistribute more
+    // than 1 sat of overpay, however, as we probably shouldn't allow one peer to recover the other
+    // peer's loss of change to dust.
+    let award_1_sat_to_buyer = overpay_total_msat > 999 && buyer_has_change
+        && (buyer_overpay_msat >= seller_overpay_msat || !seller_has_change);
+    let award_1_sat_to_seller = overpay_total_msat > 999 && seller_has_change
+        && !award_1_sat_to_buyer;
+
+    let mut merged_psbt = seller_psbt.clone();
+    let seller_tx_input = re(&mut merged_psbt.unsigned_tx.input, &buyer_psbt.unsigned_tx.input);
+    let seller_tx_output = re(&mut merged_psbt.unsigned_tx.output, &buyer_psbt.unsigned_tx.output);
+    let seller_inputs = re(&mut merged_psbt.inputs, &buyer_psbt.inputs);
+    let seller_outputs = re(&mut merged_psbt.outputs, &buyer_psbt.outputs);
+    if merged_psbt != *buyer_psbt {
+        return Err(TransactionErrorKind::InvalidPsbt);
+    }
+    merged_psbt.unsigned_tx.input.append(&mut id(seller_tx_input));
+    merged_psbt.unsigned_tx.output.append(&mut id(seller_tx_output));
+    merged_psbt.inputs.append(&mut id(seller_inputs));
+    merged_psbt.outputs.append(&mut id(seller_outputs));
+
+    let seller_output_start = buyer_psbt.outputs.len();
+    if award_1_sat_to_buyer {
+        merged_psbt.unsigned_tx.output[1].value += Amount::ONE_SAT;
+    }
+    if award_1_sat_to_seller {
+        let i = seller_output_start + 1 + num_receivers;
+        merged_psbt.unsigned_tx.output[i].value += Amount::ONE_SAT;
+    }
+    // Move the seller's placeholder output to the 2nd position (after the buyer's) for convenience:
+    (&mut merged_psbt.outputs[..], &mut merged_psbt.unsigned_tx.output[..])
+        .swap(1, seller_output_start);
+
+    Ok(merged_psbt)
+}
+
+pub fn set_payouts_and_shuffle(psbt: &mut Psbt, buyer_payout: &mut TxOutput, seller_payout: &mut TxOutput) {
+    let seed = psbt.unsigned_tx.compute_txid().to_byte_array();
+    psbt.unsigned_tx.output[0] = buyer_payout.1.clone();
+    psbt.unsigned_tx.output[1] = seller_payout.1.clone();
+    [buyer_payout.0.vout, seller_payout.0.vout] = [0, 1];
+
+    let mut rng = ChaCha20Rng::from_seed(seed);
+    (&mut psbt.inputs[..], &mut psbt.unsigned_tx.input[..])
+        .shuffle(&mut rng);
+    (&mut psbt.outputs[..], (&mut psbt.unsigned_tx.output[..],
+        (&mut buyer_payout.0.vout, &mut seller_payout.0.vout)))
+        .shuffle(&mut rng);
+
+    let txid = psbt.unsigned_tx.compute_txid();
+    [buyer_payout.0.txid, seller_payout.0.txid] = [txid; 2];
+}

--- a/rpc/src/swap.rs
+++ b/rpc/src/swap.rs
@@ -1,0 +1,65 @@
+use rand::RngCore;
+
+pub trait Swap: Sized {
+    fn len(&self) -> usize;
+
+    /// # Panics
+    /// Will panic if `i` or `j` are out of bounds
+    fn swap(self, i: usize, j: usize) -> Self;
+
+    /// # Panics
+    /// Will panic if `self.len()` is greater than `u32::MAX`
+    fn shuffle(mut self, rng: &mut impl RngCore) -> Self {
+        for j in (1..self.len()).rev() {
+            let i = loop {
+                let j_plus_1 = u32::try_from(j + 1).expect("cannot shuffle if len > u32::MAX");
+                let x = rng.next_u32();
+                if x / j_plus_1 < u32::MAX / j_plus_1 || u32::MAX % j_plus_1 == 0 {
+                    break (x % j_plus_1) as usize;
+                }
+            };
+            self = self.swap(i, j);
+        }
+        self
+    }
+}
+
+impl<T> Swap for &mut [T] {
+    fn len(&self) -> usize {
+        (**self).len()
+    }
+
+    fn swap(self, i: usize, j: usize) -> Self {
+        (*self).swap(i, j);
+        self
+    }
+}
+
+impl<T: Swap, U: Swap> Swap for (T, U) {
+    fn len(&self) -> usize {
+        self.0.len().min(self.1.len())
+    }
+
+    fn swap(self, i: usize, j: usize) -> Self {
+        assert!(i.max(j) < self.len());
+        (self.0.swap(i, j), self.1.swap(i, j))
+    }
+}
+
+impl Swap for &mut u32 {
+    fn len(&self) -> usize {
+        u32::MAX as usize
+    }
+
+    fn swap(self, i: usize, j: usize) -> Self {
+        assert!(i.max(j) < self.len());
+        #[expect(clippy::cast_possible_truncation, reason = "range check ensures no truncation")]
+        let (i, j) = (i as u32, j as u32);
+        if *self == i {
+            *self = j;
+        } else if *self == j {
+            *self = i;
+        }
+        self
+    }
+}


### PR DESCRIPTION
Provide partially mocked deposit PSBT buyer/seller halves, in place of empty dummy PSBTs, in the mocked-up trade protocol of the `rpc` crate, together with code to merge and shuffle their inputs & outputs.

Each PSBT half has a special `OP_RETURN` placeholder output (with a randomised 27-byte datagram) _burning_ the trader's deposit. Then, when the halves are merged, the placeholders are replaced with the real payout UTXOs. The length of the placeholder output is chosen to make the weights of the two PSBT halves sum to a weight as close to that of the final signed Deposit Tx as possible. (The sum is just 2 wu more.) This should make it simpler to achieve an accurate fee rate for the final Deposit Tx, while minimising the chance of BDK needlessly adding extra coins and change outputs when the input coins are just enough to cover the trader's respective deposit.

Add `rand_chacha` to the `rpc` crate dependencies (which is already a transitive dependency via `rand`), in order to use its `ChaCha20Rng` PRNG to implement a stable, portable and reasonably secure deterministic shuffling of the deposit PSBT inputs & outputs. (Also bump dependency patch versions and run `cargo update`.)

--

Also add code to actually sign the Swap Tx (and other prepared txs) and recover its signature, so that a real signed Swap Tx can be passed between the Bisq2 client and the Rust server, instead of just directly passing a `LiftedSignature` masquerading as the Swap Tx for test/development purposes.

--

**TODO:** Add much more thorough validation of the peer's deposit PSBT half.
**TODO:** Add shuffle algorithm stability/portability regression tests.
**TODO:** Attempt to replace remaining mocking (such as dummy claim payout/anchor addresses) in `rpc::protocol` with a single mock trade wallet exposing address & deposit PSBT-half generation and PSBT signing / (mock) broadcast.
