### PR TITLE
style: add precommit hooks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ If you want to get a feeling about this project, check it out and start the test
 , please see this section [Running Integration Tests](./adaptor/README.md).
 Accepted contributions are eligible for compensation, so you could earn money for your work.
 
+## Setting up precommit hooks
+
+The project comes bundle with a git pre-commit hook script that lints and format the code before each commits.
+To set it up you need to run the following command.
+
+`bash install-hooks.sh`
+
+**NOTE**: Make sure you have `jq` installed
+
+The command will copy the pre-commit script to your local `.git/hooks/pre-commit` file.
+This helps us keeping clean build and focus on the essentials parts when reviewing pull requests.
+
 ## running the tests
 
 to run the test you need a work regtest environment as provided by nigiri. You may need to

--- a/install-hooks.sh
+++ b/install-hooks.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# This script automates the installation of pre-commit hooks
+# Any contributor needs to run this before starting making contributions to the project.
+
+cd .git/hooks
+if [ ! -f pre-commit ]; then
+    cat << 'EOF' > pre-commit
+#!/bin/bash
+
+RED="\033[31m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+BLUE="\033[34m"
+RESET="\033[0m"
+
+ROOT=$(git rev-parse --show-toplevel)
+
+# Check if jq is installed
+if ! command -v jq &> /dev/null; then
+    echo -e "${RED}PRE-COMMIT: jq is not installed. Please install jq to proceed.${RESET}"
+    exit 1
+fi
+
+# Only require fixing warnings of modified files, so that preexisting code with warnings shouldn't stop us from committing.
+# cargo clippy can't be applied to specific file so we run it and parse its output to get the files involved and compare them with modified git files
+
+echo -e "${BLUE}PRE-COMMIT: Running cargo clippy --quiet${RESET}"
+
+CLIPPY_OUTPUT=$(cargo clippy --quiet --message-format=json \
+  | jq -r '.message.rendered? // empty')
+
+GIT_DIFF_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+FILES_WITH_WARNINGS=$(echo "$CLIPPY_OUTPUT" | grep -Ff <(echo "$GIT_DIFF_FILES") || true)
+
+if [ -n "$FILES_WITH_WARNINGS" ]; then
+  echo "$FILES_WITH_WARNINGS" | while IFS= read -r line; do
+    if [[ "$line" == *"-->"* ]]; then
+      file=$(echo "$line" | awk '{print $2}')
+      echo -e "${YELLOW} Please fix warnings in file:${RESET} ${GREEN}$file${RESET}"
+    else
+      echo "$line"
+    fi
+  done
+  exit 1
+fi
+
+# Run formatting, this runs only on modified files
+# This requires nightly channel because --skip-children isn't a stable feature of rustfmt
+# --skip-children is needed so that rustfmt doesn't recurse and update formatting of unmodified files
+
+echo -e "${BLUE}PRE-COMMIT: Running cargo fmt${RESET}"
+
+for file in $(git diff --cached --name-only --diff-filter=ACM | grep ".rs$"); do
+  PATH_FILE="$ROOT/$file"
+  $(rustfmt +nightly --unstable-features --skip-children --edition 2021 -- "$PATH_FILE")
+  git add "$PATH_FILE"
+done
+
+# Insert new line at the end of modified files if none.
+
+echo -e "${BLUE}PRE-COMMIT: Adding new line at the end ${RESET}"
+
+for file in $GIT_DIFF_FILES; do
+  if file "$file" | grep -q "text"; then
+    if [ -s "$file" ] && [ -n "$(tail -c1 "$file")" ]; then
+      echo >> "$file"
+      git add $file
+    fi
+  fi
+done
+
+EOF
+chmod +x pre-commit
+fi

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,8 @@
+comment_width = 100
+format_code_in_doc_comments = true
+wrap_comments = true
+reorder_imports = true
+edition = "2021"
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+style_edition = "2021"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,8 +1,8 @@
 comment_width = 100
 format_code_in_doc_comments = true
 wrap_comments = true
-reorder_imports = true
+reorder_imports = false
 edition = "2021"
 imports_granularity = "Crate"
-group_imports = "StdExternalCrate"
+group_imports = "Preserve"
 style_edition = "2021"


### PR DESCRIPTION
This PR adds a precommit hook script that will get executed and check for lints, formatting and any further setting we might want in the future.

# Installation

The installation of the script is done by running the command `bash install-hooks.sh`
This will copy the script to local `.git/hooks/pre-commit` script file.

# Checked requirements
The current script before committing does the following:

1- Run `cargo clippy` on the modified files and reports the file that style have warnings
2- Run `rustfmt`
3- Add a new line at the end of file if none