### PR TITLE
Fix blanket-suppressed Clippy warnings in `protocol` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ tail_expr_drop_order = { level = "allow", priority = 1 }
 pedantic = "warn"
 # Enable selected 'nursery' and 'restriction' lints...
 allow_attributes = "warn"
-allow_attributes_without_reason = "warn"
 branches_sharing_code = "warn"
 exhaustive_enums = "warn"
 iter_on_empty_collections = "warn"

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -71,7 +71,7 @@ mod tests {
         bob.round5(alice_r4)?;
 
         // done -----------------------------
-        crate::nigiri::tiktok();
+        nigiri::tiktok();
         Ok((alice, bob))
     }
 
@@ -82,7 +82,7 @@ mod tests {
         dbg!(&alice.swap_tx.tx);
         dbg!(&bob.swap_tx.tx);
 
-        // alice broadcats SwapTx
+        // alice broadcasts SwapTx
         let alice_swap = alice.swap_tx.sign(&alice.p_tik)?;
         dbg!(alice.swap_tx.broadcast(&alice.ctx));
         nigiri::tiktok();
@@ -91,20 +91,21 @@ mod tests {
         // cheating and using the transaction from alice directly
         bob.swap_tx.reveal(&alice_swap, &mut bob.p_tik)?;
         assert!(bob.p_tik.agg_sec.is_some(), "We should have the aggregated secret key now");
-        assert!(bob.p_tik.other_sec.unwrap() == alice.p_tik.sec, "Bob should have Alice secret key for p_tik");
+        assert_eq!(bob.p_tik.other_sec.unwrap(), alice.p_tik.sec, "Bob should have Alice secret key for p_tik");
         // TODO now make a arbitrary transaction with the key into own wallet.
 
         Ok(())
     }
 
-    // TODO write a test where Bob does not sign DepositTx but Alice has it already. Bob needs to remove the funds from the INPUT OF dEPOSITtX.
+    // TODO write a test where Bob does not sign DepositTx but Alice has it already. Bob needs to
+    //  remove the funds from the INPUT OF DepositTx.
 
     #[test]
     fn test_warning() -> anyhow::Result<()> {
         // create all transaction and Broadcast DepositTx already
         let (alice, _bob) = initial_tx_creation()?;
         dbg!(&alice.warning_tx_me.tx);
-        // alice broadcats WarningTx
+        // alice broadcasts WarningTx
         dbg!(alice.warning_tx_me.broadcast(&alice.ctx));
         nigiri::tiktok();
         Ok(())
@@ -115,7 +116,7 @@ mod tests {
         // create all transaction and Broadcast DepositTx already
         let (alice, _bob) = initial_tx_creation()?;
         // dbg!(&alice.warning_tx_me.tx);
-        // alice broadcats WarningTx
+        // alice broadcasts WarningTx
         alice.warning_tx_me.broadcast(&alice.ctx);
         nigiri::tiktok();
         nigiri::tiktok(); // we have set time-delay t2 to 2 Blocks
@@ -153,7 +154,7 @@ mod tests {
                 let error_message = format!("{e:?}");
                 // println!("{}", error_message);
                 assert!(error_message.contains("non-BIP68-final"),
-                    "Wrong Errormessage: {error_message}");
+                    "Wrong error message: {error_message}");
             }
         }
         nigiri::tiktok();
@@ -165,7 +166,7 @@ mod tests {
         // create all transaction and Broadcast DepositTx already
         let (alice, bob) = initial_tx_creation()?;
         // dbg!(&alice.warning_tx_me.tx);
-        // alice broadcats WarningTx
+        // alice broadcasts WarningTx
         let bob_warn_id = bob.warning_tx_me.broadcast(&bob.ctx);
         nigiri::tiktok();
         dbg!(bob_warn_id);
@@ -176,7 +177,7 @@ mod tests {
         Ok(())
     }
 
-    //noinspection ALL
+    //noinspection SpellCheckingInspection
     #[test]
     fn test_q_tik() -> anyhow::Result<()> {
         // create all transaction and Broadcast DepositTx already
@@ -200,7 +201,7 @@ mod tests {
         // path 1: secp sig  -----------------------------
 
         // let grab the keys and produce new sig
-        let seckeys: Vec<musig2::secp::Scalar>
+        let seckeys: Vec<Scalar>
             = if alice.q_tik.pub_point < bob.q_tik.pub_point {
             vec![alice.q_tik.sec, bob.q_tik.sec]
         } else {
@@ -213,7 +214,7 @@ mod tests {
         let secp = Secp256k1::new();
         let keypair = Keypair::from_seckey_slice(&secp, &agg_sec.serialize())?;
         let tweaked: TweakedKeypair = keypair.tap_tweak(&secp, None);
-        let sig1 = secp.sign_schnorr(&msg, &keypair); // wsill end up in Bad Signature
+        let sig1 = secp.sign_schnorr(&msg, &keypair); // will end up in Bad Signature
         // let sig1 = secp.sign_schnorr(&msg, &tweaked.to_inner());
         // Update the witness stack.
         let signature_secp = bitcoin::taproot::Signature { signature: sig1, sighash_type };
@@ -236,18 +237,17 @@ mod tests {
         let ac = agg_ctx.pubkeys();
         let pks = if ac[0] < ac[1] { [ac[0], ac[1]] } else { [ac[1], ac[0]] };
         let newctx = KeyAggContext::new(pks)?;
-        dbg!(&newctx,&ac,&pks);
+        dbg!(&newctx, &ac, &pks);
         let newaggkey: Point = newctx.aggregated_pubkey();
         let newctx2 = newctx.with_unspendable_taproot_tweak()?;
         let newtweaked: Point = newctx2.aggregated_pubkey();
 
-        assert_eq!(&newaggkey, &newctx2.aggregated_pubkey_untweaked(), "newaggkey not equal");
-
+        assert_eq!(newaggkey, newctx2.aggregated_pubkey_untweaked(), "newaggkey not equal");
 
         // verify ------------------------------------------
-        dbg!(&path1pubpoint,&path1tweakpoint, &d, &aggkey, &old_d,&newtweaked,&newaggkey);
+        dbg!(&path1pubpoint, &path1tweakpoint, &d, &aggkey, &old_d, &newtweaked, &newaggkey);
 
-        assert_eq!(&d.serialize(), &tweaked.to_keypair().public_key().serialize(), "pubkey not equal");
+        assert_eq!(d.serialize(), tweaked.to_keypair().public_key().serialize(), "pubkey not equal");
         // assert_eq!(dser, my_agg_point.serialize(), "my pubkey not equal");
 
         // use signature and broadcast ------------------------------------------

--- a/protocol/src/nigiri.rs
+++ b/protocol/src/nigiri.rs
@@ -1,6 +1,3 @@
-// FIXME: Temporarily suppressed warnings in order to get a clean build:
-#![allow(warnings)]
-
 // Bitcoin and BDK-related imports
 
 use crate::protocol_musig_adaptor::MemWallet;
@@ -18,13 +15,13 @@ pub fn fund_wallet(wallet: &mut MemWallet) {
     let initial_balance = wallet.balance();
     // load some more coin to wallet
     let adr = wallet.next_unused_address().to_string();
-    println!("address = {}", adr);
-    fund_address(&*adr);
+    println!("address = {adr}");
+    fund_address(&adr);
     loop {
         thread::sleep(time::Duration::from_secs(1));
         wallet.sync().unwrap();
         let balance = wallet.balance();
-        println!("\nCurrent wallet amount: {}", balance);
+        println!("\nCurrent wallet amount: {balance}");
 
         if balance > initial_balance {
             break;
@@ -41,14 +38,14 @@ fn fund_address(address: &str) {
     eprintln!("{}", String::from_utf8_lossy(&faucet_response.stdout));
     // thread::sleep(time::Duration::from_secs(2)); // Add delays between steps
 
-    eprintln!("Mining mining to {}", address);
+    eprintln!("Mining mining to {address}");
     let resp = mine(address, 1);
     eprintln!("reponse {}", String::from_utf8_lossy(&resp.stdout));
 }
 
 const FUND_ADDRESS: &str = "bcrt1plrmcqc9pwf4zjcej5n7ynre5k8lkn0xcz0c7y3dw37e8nqew2utq5l06jv";
 
-pub(crate) fn tiktok() -> Output {
+pub fn tiktok() -> Output {
     mine(FUND_ADDRESS, 1)
 }
 fn mine(address: &str, num_blocks: u16) -> Output {
@@ -69,11 +66,8 @@ pub(crate) fn check_start() {
         eprintln!("Nigiri started successfully.");
     } else {
         let msg = String::from_utf8_lossy(&nigiri_output.stderr);
-        if !msg.contains("already running") {
-            panic!(
-                "Failed to start Nigiri. Please install Docker and Nigiri manually. Error: {}",
-                String::from_utf8_lossy(&nigiri_output.stderr)
-            );
-        }
+        assert!(msg.contains("already running"),
+            "Failed to start Nigiri. Please install Docker and Nigiri manually. Error: {}",
+            String::from_utf8_lossy(&nigiri_output.stderr));
     }
 }

--- a/protocol/src/nigiri.rs
+++ b/protocol/src/nigiri.rs
@@ -1,9 +1,8 @@
-// Bitcoin and BDK-related imports
+use bdk_wallet::bitcoin::Amount;
+use std::process::{Command, Output};
+use std::{thread, time};
 
 use crate::protocol_musig_adaptor::MemWallet;
-use bdk_wallet::bitcoin::Amount;
-use std::process::Output;
-use std::{process::Command, thread, time};
 
 pub fn funded_wallet() -> MemWallet {
     println!("loading wallet...");
@@ -11,6 +10,7 @@ pub fn funded_wallet() -> MemWallet {
     fund_wallet(&mut wallet);
     wallet
 }
+
 pub fn fund_wallet(wallet: &mut MemWallet) {
     let initial_balance = wallet.balance();
     // load some more coin to wallet
@@ -40,14 +40,16 @@ fn fund_address(address: &str) {
 
     eprintln!("Mining mining to {address}");
     let resp = mine(address, 1);
-    eprintln!("reponse {}", String::from_utf8_lossy(&resp.stdout));
+    eprintln!("response {}", String::from_utf8_lossy(&resp.stdout));
 }
 
+//noinspection SpellCheckingInspection
 const FUND_ADDRESS: &str = "bcrt1plrmcqc9pwf4zjcej5n7ynre5k8lkn0xcz0c7y3dw37e8nqew2utq5l06jv";
 
 pub fn tiktok() -> Output {
     mine(FUND_ADDRESS, 1)
 }
+
 fn mine(address: &str, num_blocks: u16) -> Output {
     Command::new("nigiri")
         .args(["rpc", "generatetoaddress", &num_blocks.to_string(), address])

--- a/protocol/src/protocol_musig_adaptor.rs
+++ b/protocol/src/protocol_musig_adaptor.rs
@@ -48,7 +48,7 @@ impl MemWallet {
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
-#[expect(clippy::exhaustive_enums, reason = "should be exhaustive in this case")]
+#[expect(clippy::exhaustive_enums)]
 pub enum ProtocolRole {
     Seller,
     Buyer,

--- a/protocol/src/transaction.rs
+++ b/protocol/src/transaction.rs
@@ -629,9 +629,8 @@ impl From<ExtractTxError> for TransactionErrorKind {
 
 #[cfg(test)]
 mod tests {
-    use bdk_wallet::bitcoin::Network;
-    use bdk_wallet::bitcoin::consensus;
     use bdk_wallet::bitcoin::hex::test_hex_unwrap as hex;
+    use bdk_wallet::bitcoin::{Network, consensus};
     use const_format::str_index;
     use rand::SeedableRng as _;
     use rand_chacha::ChaCha20Rng;


### PR DESCRIPTION
To make future modification of the BMP implementation in the `protocol` crate easier, this PR removes the blanket Clippy/`rustc` warning suppressions for `lib.rs`, `protocol_musig_adaptor.rs` & `nigiri.rs`, and instead fixes/suppresses each warning individually. In this way, any further changes to those files will have Clippy coverage.

Some additional minor cleanup is done by the PR:
- Fix IDE warnings not covered by any Clippy lints, e.g. using `assert!` where `assert_eq!` could be used;
- Fix typos flagged by the IDE;
- Autoformat using IDEA (was already largely formatted as such -- required moving some comments to the previous line);
- Make minor whitespace changes, adding/removing some newlines;
- Canonicalise import lists in agreement with `rustfmt`.
