### PR TITLE
tests: wallet integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2701,6 +2701,7 @@ dependencies = [
  "secp",
  "simple-semaphore",
  "tempfile",
+ "testenv",
  "zeroize",
 ]
 

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -21,3 +21,4 @@ tempfile = "3.23.0"
 bdk_wallet = { workspace = true , features = ["test-utils"]}
 simple-semaphore = "0.2.0"
 once_cell = "1.21"
+testenv = { path = "../testenv"}

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -13,3 +13,13 @@ It currently provides the following features:
 `cd wallet`
 
 `cargo test`
+
+# Running integration tests
+
+In order to run the integrations tests:
+
+`cargo test --test wallet_integration_test`
+
+If you want to display the tests stdout, add the option `--show-output` as follow:
+
+`cargo test --test wallet_integration_test -- --show-output`

--- a/wallet/tests/wallet_integration_test.rs
+++ b/wallet/tests/wallet_integration_test.rs
@@ -1,0 +1,283 @@
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Ok;
+use bdk_electrum::electrum_client::{Client, Config, ElectrumApi};
+use bdk_electrum::BdkElectrumClient;
+use bdk_wallet::bitcoin::key::Secp256k1;
+use bdk_wallet::bitcoin::secp256k1::All;
+use bdk_wallet::bitcoin::{Address, Amount, KnownHrp, Network, XOnlyPublicKey};
+use bdk_wallet::psbt::PsbtUtils;
+use bdk_wallet::{KeychainKind, SignOptions};
+use rand::RngCore;
+use secp::Scalar;
+use simple_semaphore::Semaphore;
+use tempfile::{tempdir, TempDir};
+use testenv::TestEnv;
+use wallet::bmp_wallet::*;
+
+static SEMAPHORE: once_cell::sync::Lazy<Arc<Semaphore>> =
+    once_cell::sync::Lazy::new(|| Semaphore::new(1));
+
+fn tear_up() -> TempDir {
+    let tmp_dir = tempdir().unwrap();
+    std::env::set_current_dir(tmp_dir.path()).unwrap();
+    tmp_dir
+}
+
+fn new_private_key() -> Scalar {
+    let mut seed: [u8; 32] = [0u8; 32];
+    rand::rng().fill_bytes(&mut seed);
+    Scalar::from_slice(&seed).unwrap()
+}
+
+pub fn get_address(ctx: &Secp256k1<All>, key: &Scalar) -> Address {
+    let xonly_pubkey = key.base_point_mul().serialize_xonly();
+    let pbk = XOnlyPublicKey::from_slice(&xonly_pubkey).expect("Should be valid xonlypub key");
+    Address::p2tr(ctx, pbk, None, KnownHrp::Regtest)
+}
+
+
+#[test]
+fn init_test() -> anyhow::Result<()> {
+    let _permit = SEMAPHORE.acquire();
+    let _tmp_dir = tear_up();
+
+    let env = TestEnv::new()?;
+
+    env.mine_block()?;
+
+    let mut wallet = BMPWallet::new(Network::Regtest)?;
+    let receive_amount = Amount::from_sat(100000);
+
+    let client = Client::from_config(env.electrum_url(), Config::default())?;
+    let data_source = BdkElectrumClient::new(client);
+
+    let receiving_addr = wallet.next_unused_address(KeychainKind::External);
+
+    env.fund_address(&receiving_addr, receive_amount)?;
+    env.mine_block()?;
+
+    env.wait_for_block(Duration::from_secs(5))?;
+
+    wallet.sync_all(&data_source)?;
+
+    assert_eq!(wallet.balance(), receive_amount);
+    Ok(())
+}
+
+#[test]
+fn test_sync_with_imported_keys() -> anyhow::Result<()> {
+    let _permit = SEMAPHORE.acquire();
+    let _tmp_dir = tear_up();
+
+    let env = TestEnv::new()?;
+    env.mine_block()?;
+
+    let prv_key = new_private_key();
+
+    let receive_amount = Amount::from_sat(100000);
+
+    let mut wallet = BMPWallet::new(Network::Regtest)?;
+    wallet.import_private_key(prv_key);
+
+    let client = Client::from_config(env.electrum_url(), Config::default())?;
+    let data_source = BdkElectrumClient::new(client);
+
+    let receiving_addr = wallet.next_unused_address(KeychainKind::External);
+    let imported_addr = get_address(wallet.secp_ctx(), &prv_key);
+
+    env.fund_address(&receiving_addr, receive_amount)?;
+    env.fund_address(&imported_addr, receive_amount)?;
+
+    env.mine_block()?;
+    env.wait_for_block(Duration::from_secs(5))?;
+
+    wallet.sync_all(&data_source)?;
+    assert_eq!(wallet.balance(), receive_amount + receive_amount);
+
+    Ok(())
+}
+
+#[test]
+
+fn test_broadcast_transaction() -> anyhow::Result<()> {
+    // This test broadcast a transaction created from main wallet balance only
+    let _permit = SEMAPHORE.acquire();
+    let _tmp_dir = tear_up();
+
+    let env = TestEnv::new()?;
+
+    let client = Client::from_config(env.electrum_url(), Config::default())?;
+    let data_source = BdkElectrumClient::new(client);
+
+    let prv_key = new_private_key();
+
+    let mut wallet = BMPWallet::new(Network::Regtest)?;
+    wallet.import_private_key(prv_key);
+
+    let receive_amount = Amount::from_sat(100000);
+    let to_address =
+        Address::from_str("tb1pyfv094rr0vk28lf8v9yx3veaacdzg26ztqk4ga84zucqqhafnn5q9my9rz")?;
+
+    let receiving_addr = wallet.next_unused_address(KeychainKind::External);
+
+    env.fund_address(&receiving_addr, receive_amount)?;
+
+    env.mine_block()?;
+    env.wait_for_block(Duration::from_secs(5))?;
+
+    wallet.sync_all(&data_source)?;
+
+    let mut tx_builder = wallet.build_tx();
+    let send_amount = Amount::from_sat(1000);
+    tx_builder.add_recipient(to_address.assume_checked(), send_amount);
+
+    let mut psbt = tx_builder.finish()?;
+
+    wallet.sign(&mut psbt, SignOptions::default())?;
+
+    let fee = psbt.fee_amount().unwrap();
+    // Broadcast the transaction
+    let txid = env
+        .electrum_client()
+        .transaction_broadcast(&psbt.extract_tx()?)?;
+    let _ = env.wait_for_tx(txid, Duration::from_secs(5));
+
+    env.mine_block()?;
+    env.wait_for_block(Duration::from_secs(5))?;
+
+    // Rescan the wallet to apply balance changes
+    wallet.sync_all(&data_source)?;
+
+    let new_balance = receive_amount - send_amount - fee;
+    assert_eq!(wallet.balance(), new_balance);
+
+    // Reload the wallet by encrypting it to make sure the state changes are persisted
+    let enc_wallet = wallet.encrypt("hello")?;
+    assert_eq!(enc_wallet.balance(), new_balance);
+
+    Ok(())
+}
+
+#[test]
+fn test_broadcast_transaction_two() -> anyhow::Result<()> {
+    // This test broadcast a transaction created from imported wallets only
+    let _permit = SEMAPHORE.acquire();
+    let _tmp_dir = tear_up();
+
+    let env = TestEnv::new()?;
+
+    let client = Client::from_config(env.electrum_url(), Config::default())?;
+    let data_source = BdkElectrumClient::new(client);
+
+    let prv_key = new_private_key();
+
+    let mut wallet = BMPWallet::new(Network::Regtest)?;
+    wallet.import_private_key(prv_key);
+
+    let receive_amount = Amount::from_sat(100000);
+    let to_address =
+        Address::from_str("tb1pyfv094rr0vk28lf8v9yx3veaacdzg26ztqk4ga84zucqqhafnn5q9my9rz")?;
+
+    env.fund_address(&get_address(wallet.secp_ctx(), &prv_key), receive_amount)?;
+
+    env.mine_block()?;
+    env.wait_for_block(Duration::from_secs(5))?;
+
+    wallet.sync_all(&data_source)?;
+
+    let mut tx_builder = wallet.build_tx();
+    let send_amount = Amount::from_sat(1000);
+    tx_builder.add_recipient(to_address.assume_checked(), send_amount);
+
+    let mut psbt = tx_builder.finish()?;
+
+    wallet.sign(&mut psbt, SignOptions::default())?;
+
+    let fee = psbt.fee_amount().unwrap();
+    // Broadcast the transaction
+    let txid = env
+        .electrum_client()
+        .transaction_broadcast(&psbt.extract_tx()?)?;
+    let _ = env.wait_for_tx(txid, Duration::from_secs(5));
+
+    env.mine_block()?;
+    env.wait_for_block(Duration::from_secs(5))?;
+
+    // Rescan the wallet to apply balance changes
+    wallet.sync_all(&data_source)?;
+
+    let new_balance = receive_amount - send_amount - fee;
+    assert_eq!(wallet.balance(), new_balance);
+
+    // Reload the wallet by encrypting it to make sure the state changes are persisted
+    let enc_wallet = wallet.encrypt("hello")?;
+    assert_eq!(enc_wallet.balance(), new_balance);
+
+    Ok(())
+}
+
+#[test]
+fn test_broadcast_transaction_three() -> anyhow::Result<()> {
+    // This test will attempt send a transaction created from both main wallet and imported keys
+    // balance
+    let _permit = SEMAPHORE.acquire();
+    let _tmp_dir = tear_up();
+
+    let env = TestEnv::new()?;
+
+    let client = Client::from_config(env.electrum_url(), Config::default())?;
+    let data_source = BdkElectrumClient::new(client);
+
+    let prv_key = new_private_key();
+
+    let mut wallet = BMPWallet::new(Network::Regtest)?;
+    wallet.import_private_key(prv_key);
+
+    let main_wallet_addr = wallet.next_unused_address(KeychainKind::External);
+
+    let receive_amount = Amount::from_sat(100000);
+    let to_address =
+        Address::from_str("tb1pyfv094rr0vk28lf8v9yx3veaacdzg26ztqk4ga84zucqqhafnn5q9my9rz")?;
+
+    env.fund_address(&get_address(wallet.secp_ctx(), &prv_key), receive_amount)?;
+    env.fund_address(&main_wallet_addr, receive_amount)?;
+
+    env.mine_block()?;
+    env.wait_for_block(Duration::from_secs(5))?;
+
+    wallet.sync_all(&data_source)?;
+
+    let mut tx_builder = wallet.build_tx();
+    let send_amount = Amount::from_sat(100000);
+    tx_builder.add_recipient(to_address.assume_checked(), send_amount);
+
+    let mut psbt = tx_builder.finish()?;
+
+    wallet.sign(&mut psbt, SignOptions::default())?;
+
+    let fee = psbt.fee_amount().unwrap();
+
+    // Broadcast the transaction
+    let txid = env
+        .electrum_client()
+        .transaction_broadcast(&psbt.extract_tx()?)?;
+    let _ = env.wait_for_tx(txid, Duration::from_secs(5));
+
+    env.mine_block()?;
+    env.wait_for_block(Duration::from_secs(5))?;
+
+    // Rescan the wallet to apply balance changes
+    wallet.sync_all(&data_source)?;
+
+    let new_balance = (receive_amount + receive_amount) - send_amount - fee;
+    assert_eq!(wallet.balance(), new_balance);
+
+    // Reload the wallet by encrypting it to make sure the state changes are persisted
+    let enc_wallet = wallet.encrypt("hello")?;
+    assert_eq!(enc_wallet.balance(), new_balance);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR add the integrations tests for the wallet. It takes advantage of the `testenv` crate to consume real chain data source.