### PR TITLE
feat: add continuous integration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!-- You can erase any parts of this template not applicable to your Pull Request. -->
+
+### Description
+
+<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
+
+### Notes to the reviewers
+
+<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
+of the PR were done in a specific way -->
+
+## Changelog notice
+
+<!-- Notice the release manager should include in the release tag message changelog -->
+<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->
+
+### Checklists
+
+#### All Submissions:
+
+* [ ] I've signed all my commits
+* [ ] I followed the [contribution guidelines](https://github.com/bisq-network/bisq-musig/blob/master/CONTRIBUTING.md)
+* [ ] I ran `cargo fmt` and `cargo clippy` before committing
+
+#### New Features:
+
+* [ ] I've added tests for the new feature
+* [ ] I've added docs for the new feature
+* [ ] I've updated `CHANGELOG.md`
+
+#### Bugfixes:
+
+* [ ] This pull request breaks the existing API
+* [ ] I've added tests to reproduce the issue which are now passing
+* [ ] I'm linking the issue being fixed by this PR

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -1,0 +1,128 @@
+name: CI
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      wallet: ${{ steps.filter.outputs.wallet }}
+      protocol: ${{ steps.filter.outputs.protocol }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            wallet:
+              - 'wallet/**'
+            protocol:
+              - 'protocol/**'
+
+  wallet:
+    name: Build and test wallet
+    needs: changes
+    if: needs.changes.outputs.wallet == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+        features:
+          - --features default
+          - --no-default-features
+          - --all-features
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Generate cache key
+        run: echo "${{ matrix.rust }} ${{ matrix.features }}" | tee .cache_key
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('.cache_key') }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - name: Setup Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+          components: rustfmt, clippy
+
+      - name: Build
+        run: cargo build ${{ matrix.features }}
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+  protocol:
+    name: Build and test protocol
+    needs: changes
+    if: needs.changes.outputs.protocol == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+        features:
+          - --features default
+          - --no-default-features
+          - --all-features
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Generate cache key
+        run: echo "${{ matrix.rust }} ${{ matrix.features }}" | tee .cache_key
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('.cache_key') }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - name: Setup Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+          components: rustfmt, clippy
+      - name: Build
+        run: cargo build ${{ matrix.features }}
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+      - name: Test
+        run: |
+          curl https://getnigiri.vulpem.com | bash
+          nigiri start --ci
+          cargo test -- --test-threads=1
+          nigiri stop
+
+  fmt:
+    name: Rust fmt
+    needs: changes
+    if: needs.changes.outputs.wallet == 'true' || needs.changes.outputs.protocol == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          components: rustfmt
+      - name: Check fmt
+        run: cargo fmt --all -- --check


### PR DESCRIPTION
This PR continuous integration alongside with a PR template. 
It will help have reproducible builds and behavior. 

This will help avoid situation like what PR #107 brought, which is breaking the integration tests.
It will run on either `wallet` or `protocol` folder depending on what the PR changes contain. 

This requires #108 to be merged first.