### PR TITLE
fix: wallet signing keys after reload/encrypt/decrypt

### DIFF
--- a/wallet/src/coin_selection.rs
+++ b/wallet/src/coin_selection.rs
@@ -78,14 +78,16 @@ mod tests {
         let target_amount = Amount::from_int_btc(1);
         let drain_script = ScriptBuf::default();
 
-        let res = selection_strategy.coin_select(
-            imported_utxos.clone(),
-            local_utxos.clone(),
-            FeeRate::from_sat_per_kwu(50000),
-            target_amount,
-            &drain_script,
-            &mut thread_rng(),
-        ).unwrap();
+        let res = selection_strategy
+            .coin_select(
+                imported_utxos.clone(),
+                local_utxos.clone(),
+                FeeRate::from_sat_per_kwu(50000),
+                target_amount,
+                &drain_script,
+                &mut thread_rng(),
+            )
+            .unwrap();
 
         // Target amount is 1 BTC so the selected coins + fees should be from foreign
         let selected = res.selected;

--- a/wallet/src/utils.rs
+++ b/wallet/src/utils.rs
@@ -7,7 +7,6 @@ use bdk_kyoto::bip157::tokio;
 use bdk_kyoto::{Info, Receiver, UnboundedReceiver, Warning};
 use zeroize::Zeroize;
 
-
 /// Derives a 256-bit key from a password and salt using Argon2.
 pub fn derive_key_from_password(password: &str, salt: &[u8]) -> anyhow::Result<String> {
     let argon2 = Argon2::default();

--- a/wallet/tests/wallet_integration_test.rs
+++ b/wallet/tests/wallet_integration_test.rs
@@ -303,7 +303,7 @@ async fn test_cbf_persitence() -> anyhow::Result<()> {
     let env = TestEnv::new()?;
     env.mine_blocks(1)?;
     env.wait_for_block()?;
-    
+
     let mut wallet = BMPWallet::new(Network::Regtest)?;
     let addr = wallet.next_unused_address(KeychainKind::External);
     env.fund_address(&addr, Amount::from_sat(230000))?;
@@ -313,7 +313,7 @@ async fn test_cbf_persitence() -> anyhow::Result<()> {
         env.p2p_socket_addr().unwrap(),
     )];
     env.mine_block()?;
-    wallet.sync_cbf(scan_type, peers.clone()).await?;    
+    wallet.sync_cbf(scan_type, peers.clone()).await?;
     assert_eq!(wallet.balance(), Amount::from_sat(230000));
 
     // Reload the wallet from persisted state
@@ -323,19 +323,20 @@ async fn test_cbf_persitence() -> anyhow::Result<()> {
     // Encrypt the wallet then reload it and check for balance state
     let encrypted_wallet = loaded_wallet.encrypt("secret123")?;
     let mut encrypted_wallet = encrypted_wallet.decrypt("secret123")?;
-    
+
     env.fund_address(&addr, Amount::from_sat(70000))?;
     env.mine_block()?;
     encrypted_wallet.sync_cbf(scan_type, peers.clone()).await?;
     assert_eq!(encrypted_wallet.balance(), Amount::from_sat(300000));
 
     // Create a transaction and broadcast it to the connected peer
-    let receiving_addr  = Address::from_str("tb1pyfv094rr0vk28lf8v9yx3veaacdzg26ztqk4ga84zucqqhafnn5q9my9rz")?;
+    let receiving_addr =
+        Address::from_str("tb1pyfv094rr0vk28lf8v9yx3veaacdzg26ztqk4ga84zucqqhafnn5q9my9rz")?;
     let mut tx_builder = encrypted_wallet.build_tx();
     tx_builder.add_recipient(receiving_addr.assume_checked(), Amount::from_sat(70000));
 
     let mut psbt = tx_builder.finish()?;
-    
+
     encrypted_wallet.sign(&mut psbt, SignOptions::default())?;
 
     let fee = psbt.fee_amount().unwrap();


### PR DESCRIPTION
This PR fixes an issue that happened when the wallet was reloaded or decrypted. The signing keys weren't loaded with the wallet.
The fix applied here is that we only now load the signing keys into the wallet when `sign` is called. Closes #117 