### PR TITLE
Custom payouts for mediation part 3: add HD keychain support & integration test

### DIFF
--- a/protocol/src/protocol_musig_adaptor.rs
+++ b/protocol/src/protocol_musig_adaptor.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr as _;
 
 use bdk_wallet::bitcoin::{
-    Address, Amount, FeeRate, Network, OutPoint, Psbt, Script, ScriptBuf, Transaction, TxOut, Txid,
-    relative,
+    Address, Amount, FeeRate, Network, OutPoint, Psbt, Script, ScriptBuf, TapNodeHash, Transaction,
+    TxOut, Txid, XOnlyPublicKey, relative,
 };
 use musig2::secp::{MaybeScalar, Point};
 use musig2::{PartialSignature, PubNonce};
@@ -10,6 +10,7 @@ use wallet::protocol_wallet_api::MemWallet;
 
 use crate::multisig::{KeyCtx, SigCtx};
 use crate::receiver::{Receiver, ReceiverList};
+use crate::script_paths;
 use crate::transaction::{
     DepositTxBuilder, ForwardingTxBuilder, RedirectTxBuilder, TransactionExt as _, WarningTxBuilder,
 };
@@ -36,6 +37,7 @@ pub struct Round1Parameter {
     // DepositTx --------
     pub p_a: Point,
     pub q_a: Point,
+    pub script_key: XOnlyPublicKey,
     pub dep_part_psbt: Psbt,
     // Swap Tx -----
     // public nonce
@@ -98,7 +100,9 @@ pub struct BMPProtocol {
     pub p_tik: KeyCtx,
     // Point securing Buyer deposit:
     pub q_tik: KeyCtx,
-    deposit_tx: DepositTx,
+    script_key_me: Option<XOnlyPublicKey>,
+    script_key_peer: Option<XOnlyPublicKey>,
+    pub deposit_tx: DepositTx,
     // which round are we in:
     round: u8,
     pub swap_tx: SwapTx,
@@ -133,6 +137,8 @@ impl BMPProtocol {
             ctx,
             p_tik,
             q_tik,
+            script_key_me: None,
+            script_key_peer: None,
             deposit_tx: DepositTx::new(),
             round: 0,
             swap_tx: SwapTx::new(role),
@@ -161,9 +167,13 @@ impl BMPProtocol {
         let redirect_anchor_spend = self.ctx.funds.next_unused_address().script_pubkey();
         self.redirect_tx_me.anchor_spend = Some(redirect_anchor_spend.clone());
 
+        let script_key = self.ctx.funds.new_internal_key()?;
+        self.script_key_me = Some(script_key);
+
         Ok(Round1Parameter {
             p_a: *self.p_tik.my_key_share()?.pub_key(),
             q_a: *self.q_tik.my_key_share()?.pub_key(),
+            script_key,
             dep_part_psbt,
             swap_script,
             warn_anchor_spend,
@@ -189,7 +199,10 @@ impl BMPProtocol {
         self.q_tik.aggregate_pub_key_shares()?;
         // now we have the aggregated key
         // so we can construct the Deposit Tx
-        self.deposit_tx.build_and_merge_tx(&mut self.ctx, bob.dep_part_psbt, &self.p_tik, &self.q_tik)?;
+        self.script_key_peer = Some(bob.script_key);
+        let [buyer_pub_key, seller_pub_key] = self.script_keys()?;
+        self.deposit_tx.build_and_merge_tx(&mut self.ctx, bob.dep_part_psbt, &self.p_tik, &self.q_tik,
+            buyer_pub_key, seller_pub_key)?;
         self.warning_tx_me.build(&mut self.ctx, &self.p_tik, &self.q_tik, &self.deposit_tx)?;
         self.warning_tx_peer.anchor_spend = Some(bob.warn_anchor_spend);
         self.warning_tx_peer.build(&mut self.ctx, &self.p_tik, &self.q_tik, &self.deposit_tx)?;
@@ -291,6 +304,14 @@ impl BMPProtocol {
         self.check_round(5);
         self.deposit_tx.transfer_sig_and_broadcast(&mut self.ctx, bob.deposit_tx_signed)?;
         Ok(())
+    }
+
+    fn script_keys(&self) -> anyhow::Result<[XOnlyPublicKey; 2]> {
+        (|| Some(if self.ctx.am_buyer() {
+            [self.script_key_me?, self.script_key_peer?]
+        } else {
+            [self.script_key_peer?, self.script_key_me?]
+        }))().ok_or_else(|| anyhow::anyhow!("Missing script key"))
     }
 
     fn check_round(&mut self, round: u8) {
@@ -466,9 +487,9 @@ impl WarningTx {
     }
 
     fn build(&mut self, ctx: &mut BMPContext, p_tik: &KeyCtx, q_tik: &KeyCtx, deposit_tx: &DepositTx) -> anyhow::Result<()> {
-        self.sig_p.set_tweaked_key_ctx(p_tik.with_taproot_tweak(None)?);
+        self.sig_p.set_tweaked_key_ctx(p_tik.with_taproot_tweak(deposit_tx.merkle_root.as_ref())?);
         self.sig_p.init_my_nonce_share()?;
-        self.sig_q.set_tweaked_key_ctx(q_tik.with_taproot_tweak(None)?);
+        self.sig_q.set_tweaked_key_ctx(q_tik.with_taproot_tweak(deposit_tx.merkle_root.as_ref())?);
         self.sig_q.init_my_nonce_share()?;
 
         //--------------------
@@ -564,7 +585,7 @@ impl SwapTx {
 
     // round 1
     pub fn build(&mut self, q_tik: &KeyCtx, p_a: Point, deposit_tx: &DepositTx, swap_spend_opt: Option<&Script>) -> anyhow::Result<()> {
-        self.fund_sig.set_tweaked_key_ctx(q_tik.with_taproot_tweak(None)?);
+        self.fund_sig.set_tweaked_key_ctx(q_tik.with_taproot_tweak(deposit_tx.merkle_root.as_ref())?);
         // SwapTx is asymmetric, both parties need to agree on P_a being the public adaptor
         // P_a is the Public key which Alice (the seller) contributes to 2of2 Multisig to lock the deposit and trade amount in the DepositTx
         // if secret key of P_a is revealed to Bob, then we has both partial keys to it and is able to spend it.
@@ -637,6 +658,7 @@ impl SwapTx {
 #[derive(Default)]
 pub struct DepositTx {
     pub builder: DepositTxBuilder,
+    pub merkle_root: Option<TapNodeHash>,
 }
 
 impl DepositTx {
@@ -666,15 +688,25 @@ impl DepositTx {
         Ok(psbt.clone())
     }
 
-    pub fn build_and_merge_tx(&mut self, ctx: &mut BMPContext, other_psbt: Psbt, p_tik: &KeyCtx, q_tik: &KeyCtx) -> anyhow::Result<()> {
+    pub fn build_and_merge_tx(
+        &mut self,
+        ctx: &mut BMPContext,
+        other_psbt: Psbt,
+        p_tik: &KeyCtx,
+        q_tik: &KeyCtx,
+        buyer_pub_key: XOnlyPublicKey,
+        seller_pub_key: XOnlyPublicKey,
+    ) -> anyhow::Result<()> {
         if ctx.am_buyer() {
             self.builder.set_sellers_half_psbt(other_psbt);
         } else {
             self.builder.set_buyers_half_psbt(other_psbt);
         }
+        self.merkle_root = Some(script_paths::deposit_payout_merkle_root(&buyer_pub_key, &seller_pub_key)?);
+        let merkle_root = self.merkle_root.as_ref();
         self.builder
-            .set_buyer_payout_address(p_tik.with_taproot_tweak(None)?.p2tr_address(Network::Regtest))
-            .set_seller_payout_address(q_tik.with_taproot_tweak(None)?.p2tr_address(Network::Regtest))
+            .set_buyer_payout_address(p_tik.with_taproot_tweak(merkle_root)?.p2tr_address(Network::Regtest))
+            .set_seller_payout_address(q_tik.with_taproot_tweak(merkle_root)?.p2tr_address(Network::Regtest))
             .compute_unsigned_tx()?;
         Ok(())
     }

--- a/protocol/src/protocol_musig_adaptor.rs
+++ b/protocol/src/protocol_musig_adaptor.rs
@@ -11,7 +11,7 @@ use wallet::protocol_wallet_api::MemWallet;
 use crate::multisig::{KeyCtx, SigCtx};
 use crate::receiver::{Receiver, ReceiverList};
 use crate::transaction::{
-    DepositTxBuilder, ForwardingTxBuilder, RedirectTxBuilder, WarningTxBuilder, WithWitnesses as _,
+    DepositTxBuilder, ForwardingTxBuilder, RedirectTxBuilder, TransactionExt as _, WarningTxBuilder,
 };
 use crate::wallet_service::WalletService;
 

--- a/protocol/src/protocol_musig_adaptor.rs
+++ b/protocol/src/protocol_musig_adaptor.rs
@@ -4,11 +4,12 @@ use bdk_wallet::bitcoin::{
     Address, Amount, FeeRate, Network, OutPoint, Psbt, Script, ScriptBuf, TapNodeHash, Transaction,
     TxOut, Txid, XOnlyPublicKey, relative,
 };
+use bdk_wallet::miniscript::{DefiniteDescriptorKey, Descriptor};
 use musig2::secp::{MaybeScalar, Point};
 use musig2::{PartialSignature, PubNonce};
 use wallet::protocol_wallet_api::MemWallet;
 
-use crate::multisig::{KeyCtx, SigCtx};
+use crate::multisig::{KeyCtx, PointExt as _, SigCtx};
 use crate::receiver::{Receiver, ReceiverList};
 use crate::script_paths;
 use crate::transaction::{
@@ -659,6 +660,8 @@ impl SwapTx {
 pub struct DepositTx {
     pub builder: DepositTxBuilder,
     pub merkle_root: Option<TapNodeHash>,
+    pub p_descriptor: Option<Descriptor<DefiniteDescriptorKey>>,
+    pub q_descriptor: Option<Descriptor<DefiniteDescriptorKey>>,
 }
 
 impl DepositTx {
@@ -703,6 +706,10 @@ impl DepositTx {
             self.builder.set_buyers_half_psbt(other_psbt);
         }
         self.merkle_root = Some(script_paths::deposit_payout_merkle_root(&buyer_pub_key, &seller_pub_key)?);
+        self.p_descriptor = Some(script_paths::deposit_payout_descriptor(
+            &p_tik.aggregated_key()?.pub_key().to_public_key().into(), &buyer_pub_key, &seller_pub_key)?);
+        self.q_descriptor = Some(script_paths::deposit_payout_descriptor(
+            &q_tik.aggregated_key()?.pub_key().to_public_key().into(), &buyer_pub_key, &seller_pub_key)?);
         let merkle_root = self.merkle_root.as_ref();
         self.builder
             .set_buyer_payout_address(p_tik.with_taproot_tweak(merkle_root)?.p2tr_address(Network::Regtest))

--- a/protocol/src/psbt.rs
+++ b/protocol/src/psbt.rs
@@ -16,7 +16,7 @@ use bdk_wallet::miniscript::{Descriptor, ToPublicKey as _};
 use bdk_wallet::{KeychainKind, SignOptions, TxOrdering, Wallet};
 use rand::{RngCore, SeedableRng as _};
 use rand_chacha::ChaCha20Rng;
-use wallet::protocol_wallet_api::MemWallet;
+use wallet::protocol_wallet_api::{MemWallet, WalletExt as _};
 
 use crate::receiver::Receiver;
 use crate::swap::Swap as _;
@@ -315,6 +315,7 @@ impl TradeWallet for Wallet {
             return Err(TransactionErrorKind::InvalidPsbt);
         }
         let mut psbt_copy = psbt.clone();
+        self.update_psbt_with_derivation_paths(&mut psbt_copy);
         self.sign(&mut psbt_copy, SignOptions { trust_witness_utxo: true, ..SignOptions::default() })?;
         for i in 0..psbt.inputs.len() {
             if is_selected(&psbt.unsigned_tx.input[i].previous_output) {
@@ -611,10 +612,12 @@ pub(crate) fn extract_signed_tx(psbt: &Psbt) -> Result<Transaction> {
 
 #[cfg(test)]
 mod tests {
+    use bdk_wallet::miniscript::psbt::PsbtInputExt as _;
     use bdk_wallet::psbt::PsbtUtils as _;
     use bdk_wallet::test_utils;
 
     use super::*;
+    use crate::script_paths::deposit_payout_descriptor;
 
     //noinspection SpellCheckingInspection
     #[test]
@@ -691,6 +694,57 @@ mod tests {
             wallet.spk_index().index_of_spk(spk).expect("missing spk").1);
 
         assert_eq!([1, 2, 3], spk_indices);
+        Ok(())
+    }
+
+    #[test]
+    fn bdk_trade_wallet_multisig_signing() -> Result<()> {
+        let descriptors = test_utils::get_test_tr_single_sig_xprv_and_change_desc();
+        let mut buyer_wallet = test_utils::get_funded_wallet_single(descriptors.0).0;
+        let mut seller_wallet = test_utils::get_funded_wallet_single(descriptors.1).0;
+
+        let payout_address = buyer_wallet.new_address()?;
+
+        // Generate buyer and seller pubkeys from their respective wallet HD keychains.
+        let internal_key =
+            &"0000000000000000000000000000000000000000000000000000000000000001".parse().unwrap();
+        let buyer_pub_key = &buyer_wallet.new_internal_key()?;
+        let seller_pub_key = &seller_wallet.new_internal_key()?;
+
+        // Input descriptor: tr({internal_key},and_v(v:pk({buyer_pub_key}),pk({seller_pub_key})))
+        let multisig_desc = deposit_payout_descriptor(internal_key, buyer_pub_key, seller_pub_key)?;
+
+        // Create a PSBT paying from a single 1 BTC dummy input into the buyer's wallet, with zero
+        // fee, and update the input metadata with the above descriptor.
+        let unsigned_tx = Transaction {
+            version: Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![TxOut {
+                value: Amount::ONE_BTC,
+                script_pubkey: payout_address.script_pubkey(),
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx)?;
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::ONE_BTC,
+            script_pubkey: multisig_desc.script_pubkey(),
+        });
+        psbt.inputs[0].update_with_descriptor_unchecked(&multisig_desc)?;
+
+        // After the buyer signs, the PSBT holds one tapscript signature but is not yet finalized.
+        buyer_wallet.sign_selected_inputs(&mut psbt, &|_| true)?;
+        assert_eq!(1, psbt.inputs[0].tap_script_sigs.len());
+        assert!(psbt.inputs[0].final_script_witness.is_none());
+
+        // After the seller signs, the PSBT is automatically finalized, clearing remaining metadata.
+        seller_wallet.sign_selected_inputs(&mut psbt, &|_| true)?;
+        assert!(psbt.inputs[0].tap_script_sigs.is_empty());
+        assert!(psbt.inputs[0].final_script_witness.is_some());
+
+        // Expected weight of signed multisig tx is 168 wu greater than that of a regular single-
+        // keyspend-input, single-P2TR-output tx (namely, `SIGNED_FORWARDING_TX_WEIGHT` = 444 wu).
+        assert_eq!(Weight::from_wu(612), psbt.extract_tx()?.weight());
         Ok(())
     }
 }

--- a/protocol/src/script_paths.rs
+++ b/protocol/src/script_paths.rs
@@ -1,34 +1,42 @@
 use bdk_wallet::bitcoin::opcodes::all::{OP_CHECKSIG, OP_CHECKSIGVERIFY, OP_CSV};
 use bdk_wallet::bitcoin::taproot::TaprootBuilder;
 use bdk_wallet::bitcoin::{ScriptBuf, TapNodeHash, XOnlyPublicKey, relative, script};
-use bdk_wallet::miniscript::{DefiniteDescriptorKey, Descriptor};
+use bdk_wallet::miniscript::{DefiniteDescriptorKey, Descriptor, Miniscript, Tap};
 
-use crate::transaction::NetworkParams;
+use crate::transaction::{NetworkParams, Result};
 
-pub fn deposit_payout_merkle_root(buyer_pub_key: &XOnlyPublicKey, seller_pub_key: &XOnlyPublicKey) -> TapNodeHash {
+pub fn deposit_payout_merkle_root(
+    buyer_pub_key: &XOnlyPublicKey,
+    seller_pub_key: &XOnlyPublicKey,
+) -> Result<TapNodeHash> {
     single_path_merkle_root(multisig_script(buyer_pub_key, seller_pub_key))
 }
 
-pub fn warning_escrow_merkle_root(claim_pub_key: &XOnlyPublicKey, network: impl NetworkParams + Copy) -> TapNodeHash {
+pub fn warning_escrow_merkle_root(
+    claim_pub_key: &XOnlyPublicKey,
+    network: impl NetworkParams + Copy,
+) -> Result<TapNodeHash> {
     single_path_merkle_root(claim_script(claim_pub_key, network.claim_lock_time()))
 }
 
-// FIXME: Can panic; improve:
 pub fn deposit_payout_descriptor(
     internal_key: &XOnlyPublicKey,
     buyer_pub_key: &XOnlyPublicKey,
     seller_pub_key: &XOnlyPublicKey,
-) -> Descriptor<DefiniteDescriptorKey> {
-    format!("tr({internal_key},and_v(v:pk({buyer_pub_key}),pk({seller_pub_key})))").parse().unwrap()
+) -> Result<Descriptor<DefiniteDescriptorKey>> {
+    Ok(format!("tr({internal_key},and_v(v:pk({buyer_pub_key}),pk({seller_pub_key})))").parse()?)
 }
 
-fn single_path_merkle_root(script: ScriptBuf) -> TapNodeHash {
-    TaprootBuilder::with_capacity(1)
+fn single_path_merkle_root(script: ScriptBuf) -> Result<TapNodeHash> {
+    // Check for repeated keys, zero locktime or any other issues when decoding to miniscript:
+    Miniscript::<XOnlyPublicKey, Tap>::parse(&script)?;
+
+    Ok(TaprootBuilder::with_capacity(1)
         .add_leaf(0, script)
         .expect("hardcoded TapTree build sequence should be valid")
         .try_into_taptree()
         .expect("hardcoded TapTree build sequence should be complete")
-        .root_hash()
+        .root_hash())
 }
 
 fn multisig_script(buyer_pub_key: &XOnlyPublicKey, seller_pub_key: &XOnlyPublicKey) -> ScriptBuf {
@@ -55,24 +63,47 @@ fn claim_script(pub_key: &XOnlyPublicKey, lock_time: relative::LockTime) -> Scri
 
 #[cfg(test)]
 mod tests {
-    use bdk_wallet::miniscript::{Miniscript, Tap};
+    use bdk_wallet::miniscript::descriptor::TapTree;
 
     use super::*;
 
     #[test]
     fn scripts_match_miniscript() {
         let buyer_pub_key =
-            "0000000000000000000000000000000000000000000000000000000000000001".parse().unwrap();
+            &"0000000000000000000000000000000000000000000000000000000000000001".parse().unwrap();
         let seller_pub_key =
-            "0000000000000000000000000000000000000000000000000000000000000002".parse().unwrap();
+            &"0000000000000000000000000000000000000000000000000000000000000002".parse().unwrap();
         let lock_time = relative::LockTime::from_height(720);
 
         let multisig_ms = format!("and_v(v:pk({buyer_pub_key}),pk({seller_pub_key}))")
             .parse::<Miniscript<XOnlyPublicKey, Tap>>().unwrap();
-        assert_eq!(multisig_ms.encode(), multisig_script(&buyer_pub_key, &seller_pub_key));
+        assert_eq!(multisig_ms.encode(), multisig_script(buyer_pub_key, seller_pub_key));
 
         let claim_ms = format!("and_v(v:pk({buyer_pub_key}),older({lock_time}))")
             .parse::<Miniscript<XOnlyPublicKey, Tap>>().unwrap();
-        assert_eq!(claim_ms.encode(), claim_script(&buyer_pub_key, lock_time));
+        assert_eq!(claim_ms.encode(), claim_script(buyer_pub_key, lock_time));
+    }
+
+    #[test]
+    fn multisig_script_matches_descriptor_leaf() {
+        let internal_key =
+            &"0000000000000000000000000000000000000000000000000000000000000001".parse().unwrap();
+        let buyer_pub_key =
+            &"0000000000000000000000000000000000000000000000000000000000000002".parse().unwrap();
+        let seller_pub_key =
+            &"0000000000000000000000000000000000000000000000000000000000000003".parse().unwrap();
+
+        let desc = deposit_payout_descriptor(internal_key, buyer_pub_key, seller_pub_key)
+            .unwrap();
+        let Descriptor::Tr(tr) = desc else {
+            panic!("expected Taproot descriptor")
+        };
+        let Some(TapTree::Leaf(ms)) = tr.tap_tree() else {
+            panic!("expected nonempty single-leaf TapTree")
+        };
+        assert_eq!(ms.encode(), multisig_script(buyer_pub_key, seller_pub_key));
+
+        let merkle_root = tr.spend_info().merkle_root().unwrap();
+        assert_eq!(merkle_root, deposit_payout_merkle_root(buyer_pub_key, seller_pub_key).unwrap());
     }
 }

--- a/protocol/src/transaction.rs
+++ b/protocol/src/transaction.rs
@@ -660,6 +660,7 @@ pub enum TransactionErrorKind {
     ExtractTx(#[from] Box<ExtractTxError>),
     CreateTx(#[from] bdk_wallet::error::CreateTxError),
     Signer(#[from] bdk_wallet::signer::SignerError),
+    Miniscript(#[from] bdk_wallet::miniscript::Error),
     Conversion(#[from] bdk_wallet::miniscript::descriptor::ConversionError),
     Wallet(#[from] wallet::protocol_wallet_api::WalletErrorKind),
     Anyhow(#[from] anyhow::Error),
@@ -965,9 +966,9 @@ mod tests {
             "fcba7ecf41bc7e1be4ee122d9d22e3333671eb0a3a87b5cdf099d59874e1940f".parse().unwrap();
 
         let buyer_input_descriptor = deposit_payout_descriptor(
-            &buyer_input_internal_key, &buyer_pub_key, &seller_pub_key);
+            &buyer_input_internal_key, &buyer_pub_key, &seller_pub_key)?;
         let seller_input_descriptor = deposit_payout_descriptor(
-            &seller_input_internal_key, &buyer_pub_key, &seller_pub_key);
+            &seller_input_internal_key, &buyer_pub_key, &seller_pub_key)?;
 
         let buyer_payout_address = "bcrt1p2zhgww7pvedvm2rg7d0zqh96crfhuudd9s0l3yc09ncaaxmuzvds5zhh8t"
             .parse::<Address<_>>()?.require_network(Network::Regtest)?;

--- a/protocol/src/transaction.rs
+++ b/protocol/src/transaction.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use bdk_wallet::bitcoin::amount::CheckedSum as _;
+use bdk_wallet::bitcoin::policy::MAX_STANDARD_TX_WEIGHT;
 use bdk_wallet::bitcoin::psbt::ExtractTxError;
 use bdk_wallet::bitcoin::sighash::{Prevouts, SighashCache};
 use bdk_wallet::bitcoin::taproot::{Signature, TAPROOT_ANNEX_PREFIX};
@@ -139,7 +140,7 @@ impl TxOutput {
     }
 }
 
-pub trait WithWitnesses: Sized {
+pub trait TransactionExt: Sized {
     /// # Panics
     /// Will panic if `input_index` is out of bounds
     #[must_use]
@@ -148,9 +149,13 @@ pub trait WithWitnesses: Sized {
     fn key_spend_signature(&self, input_index: usize) -> Result<Signature>;
 
     fn find_key_spend_signature(&self, input: &TxOutput) -> Result<Signature>;
+
+    fn check_no_dust_outputs(&self) -> Result<()>;
+
+    fn check_standard_weight(&self) -> Result<()>;
 }
 
-impl WithWitnesses for Transaction {
+impl TransactionExt for Transaction {
     fn with_key_spend_witness(mut self, input_index: usize, signature: &Signature) -> Self {
         self.input[input_index].witness = Witness::p2tr_key_spend(signature);
         self
@@ -176,6 +181,23 @@ impl WithWitnesses for Transaction {
             }
         }
         Err(TransactionErrorKind::MissingSignature)
+    }
+
+    fn check_no_dust_outputs(&self) -> Result<()> {
+        for (i, o) in self.output.iter().enumerate() {
+            if o.value < o.script_pubkey.minimal_non_dust() {
+                return Err(TransactionErrorKind::DustOutput(o.value, i));
+            }
+        }
+        Ok(())
+    }
+
+    fn check_standard_weight(&self) -> Result<()> {
+        let weight = self.weight();
+        if weight.to_wu() > u64::from(MAX_STANDARD_TX_WEIGHT) {
+            return Err(TransactionErrorKind::NonstandardTxWeight(weight));
+        }
+        Ok(())
     }
 }
 
@@ -285,6 +307,7 @@ impl DepositTxBuilder {
             script_pubkey: self.seller_payout_address()?.script_pubkey(),
         });
         set_payouts_and_shuffle(&mut psbt, &mut buyer_payout, &mut seller_payout);
+        psbt.unsigned_tx.check_no_dust_outputs()?;
 
         // Initialize the computed fields.
         self.psbt = Some(psbt);
@@ -375,6 +398,7 @@ impl WarningTxBuilder {
             input: self.tx_ins(*self.lock_time()?)?.to_vec(),
             output: vec![escrow_output, anchor_output],
         };
+        tx.check_no_dust_outputs()?;
         self.txid = Some(self.unsigned_tx.get_or_insert(tx).compute_txid());
         Ok(self)
     }
@@ -453,6 +477,7 @@ impl RedirectTxBuilder {
             input: self.tx_ins(*self.lock_time()?)?.to_vec(),
             output,
         };
+        tx.check_no_dust_outputs()?;
         self.txid = Some(self.unsigned_tx.get_or_insert(tx).compute_txid());
         Ok(self)
     }
@@ -463,6 +488,7 @@ impl RedirectTxBuilder {
 
     pub fn compute_signed_tx(&mut self) -> Result<&mut Self> {
         let tx = self.unsigned_tx()?.clone().with_key_spend_witness(0, self.input_signature()?);
+        tx.check_standard_weight()?;
         self.signed_tx.get_or_insert(tx);
         Ok(self)
     }
@@ -512,6 +538,7 @@ impl ForwardingTxBuilder {
             input: self.tx_ins(*self.lock_time()?)?.to_vec(),
             output,
         };
+        tx.check_no_dust_outputs()?;
         self.unsigned_tx.get_or_insert(tx);
         Ok(self)
     }
@@ -559,13 +586,13 @@ impl CustomPayoutTxBuilder {
     make_getter_setter!(fee_rate: FeeRate);
     make_getter!(psbt: Psbt: Transaction);
 
-    // FIXME: We need to enforce dust limits and prevent fee over/underpayment due to non-P2TR payout addresses.
     fn payout_amounts(
         input_amounts: impl IntoIterator<Item=Amount>,
         seller_payout_amount_excluding_fee: Amount,
+        signed_tx_weight: Weight,
         fee_rate: FeeRate,
     ) -> Option<[Amount; 2]> {
-        let total_fee = fee_rate.checked_mul_by_weight(SIGNED_CUSTOM_PAYOUT_TX_WEIGHT)?;
+        let total_fee = fee_rate.checked_mul_by_weight(signed_tx_weight)?;
         let seller_payout = seller_payout_amount_excluding_fee
             .checked_sub(total_fee / 2)?;
         let buyer_payout = input_amounts.into_iter().checked_sum()?.checked_sub(seller_payout)?
@@ -574,18 +601,29 @@ impl CustomPayoutTxBuilder {
     }
 
     pub fn compute_unsigned_tx(&mut self) -> Result<&mut Self> {
+        const P2TR_SPK_WEIGHT: Weight = Weight::from_wu(34 * 4);
+        let buyer_payout_spk = self.buyer_payout_address()?.script_pubkey();
+        let seller_payout_spk = self.seller_payout_address()?.script_pubkey();
+
+        // In exceptional cases, the payout addresses may not in fact be P2TR, so correct for that
+        // in the final tx weight estimate and resultant tx fee & payout amounts.
+        let signed_tx_weight = SIGNED_CUSTOM_PAYOUT_TX_WEIGHT
+            + Weight::from_wu_usize(buyer_payout_spk.len() * 4) - P2TR_SPK_WEIGHT
+            + Weight::from_wu_usize(seller_payout_spk.len() * 4) - P2TR_SPK_WEIGHT;
+
         let [buyer_payout_amount, seller_payout_amount] = Self::payout_amounts(
             self.inputs()?.map(|input| input.prevout.value),
             *self.seller_payout_amount_excluding_fee()?,
+            signed_tx_weight,
             *self.fee_rate()?,
         ).ok_or(TransactionErrorKind::Overflow)?;
         let buyer_payout = TxOut {
             value: buyer_payout_amount,
-            script_pubkey: self.buyer_payout_address()?.script_pubkey(),
+            script_pubkey: buyer_payout_spk,
         };
         let seller_payout = TxOut {
             value: seller_payout_amount,
-            script_pubkey: self.seller_payout_address()?.script_pubkey(),
+            script_pubkey: seller_payout_spk,
         };
         let tx = Transaction {
             version: Version::TWO,
@@ -593,6 +631,7 @@ impl CustomPayoutTxBuilder {
             input: self.tx_ins(LockTime::ZERO)?.to_vec(),
             output: vec![buyer_payout, seller_payout],
         };
+        tx.check_no_dust_outputs()?;
         let mut psbt = Psbt::from_unsigned_tx(tx).expect("tx is unsigned by construction");
         psbt.inputs[0].witness_utxo = Some(self.buyer_input()?.prevout.clone());
         psbt.inputs[1].witness_utxo = Some(self.seller_input()?.prevout.clone());
@@ -652,6 +691,10 @@ pub enum TransactionErrorKind {
     InvalidWitness,
     #[error("invalid PSBT")]
     InvalidPsbt,
+    #[error("dust output of {0} at index {1}")]
+    DustOutput(Amount, usize),
+    #[error("transaction weight {0} exceeds policy maximum")]
+    NonstandardTxWeight(Weight),
     AddressParse(#[from] bdk_wallet::bitcoin::address::ParseError),
     Taproot(#[from] bdk_wallet::bitcoin::sighash::TaprootError),
     InputsIndex(#[from] bdk_wallet::bitcoin::transaction::InputsIndexError),

--- a/protocol/tests/protocol_integration_tests.rs
+++ b/protocol/tests/protocol_integration_tests.rs
@@ -23,13 +23,12 @@ fn test_initial_tx_creation() -> anyhow::Result<()> {
 
 pub fn funded_wallet(env: &mut TestEnv) -> MemWallet {
     // TODO move this line to TestEnv
-    let client =
-            BdkElectrumClient::new(Client::new(&env.electrum_url()).unwrap());
+    let client = BdkElectrumClient::new(Client::new(&env.electrum_url()).unwrap());
     let mut wallet = MemWallet::new(client).unwrap();
     let address = wallet.next_unused_address();
     let txid = env
-            .fund_address(&address, Amount::from_btc(10f64).unwrap())
-            .unwrap();
+        .fund_address(&address, Amount::from_btc(10f64).unwrap())
+        .unwrap();
     env.mine_block().unwrap();
     env.wait_for_tx(txid).unwrap();
     wallet.sync().unwrap();
@@ -219,7 +218,8 @@ fn test_q_tik() -> anyhow::Result<()> {
     let agg_sec = *q_tik.aggregate_prv_key_shares()?;
     let secp = Secp256k1::new();
     let keypair = Keypair::from_seckey_slice(&secp, &agg_sec.serialize())?;
-    let tweaked: TweakedKeypair = keypair.tap_tweak(&secp, None);
+    let merkle_root = alice.deposit_tx.merkle_root;
+    let tweaked: TweakedKeypair = keypair.tap_tweak(&secp, merkle_root);
     // let sig1 = secp.sign_schnorr(&msg, &keypair); // will end up in Bad Signature
     let sig1 = secp.sign_schnorr(&msg, &tweaked.to_keypair());
     // Update the witness stack.
@@ -228,8 +228,8 @@ fn test_q_tik() -> anyhow::Result<()> {
     let path1_pub_point = Point::from_slice(&keypair.public_key().serialize())?;
     let path1_tweak_point = Point::from_slice(&tweaked.to_keypair().public_key().serialize())?;
 
-    // KeyAgg with no_merkle -------
-    let d: TweakedPublicKey = q_tik.with_taproot_tweak(None)?.tweaked_public_key();
+    // KeyAgg with merkle root copied from `alice.deposit_tx` -------
+    let d: TweakedPublicKey = q_tik.with_taproot_tweak(merkle_root.as_ref())?.tweaked_public_key();
     // How to do the signature with Point d and secure key?
 
     // AggKey ----------------------------------------------

--- a/protocol/tests/protocol_integration_tests.rs
+++ b/protocol/tests/protocol_integration_tests.rs
@@ -8,7 +8,7 @@ use bmp_tracing::tracing;
 use musig2::KeyAggContext;
 use musig2::secp::Point;
 use protocol::protocol_musig_adaptor::{BMPContext, BMPProtocol, ProtocolRole};
-use protocol::transaction::WithWitnesses as _;
+use protocol::transaction::TransactionExt as _;
 use protocol::wallet_service::WalletService;
 use testenv::TestEnv;
 use wallet::protocol_wallet_api::MemWallet;

--- a/protocol/tests/protocol_integration_tests.rs
+++ b/protocol/tests/protocol_integration_tests.rs
@@ -3,12 +3,12 @@ use bdk_electrum::electrum_client::Client;
 use bdk_wallet::bitcoin;
 use bitcoin::key::{Keypair, Secp256k1, TapTweak as _, TweakedKeypair, TweakedPublicKey};
 use bitcoin::secp256k1::Message;
-use bitcoin::{Amount, TapSighashType};
+use bitcoin::{Amount, FeeRate, TapSighashType};
 use bmp_tracing::tracing;
 use musig2::KeyAggContext;
 use musig2::secp::Point;
 use protocol::protocol_musig_adaptor::{BMPContext, BMPProtocol, ProtocolRole};
-use protocol::transaction::TransactionExt as _;
+use protocol::transaction::{CustomPayoutTxBuilder, TransactionExt as _};
 use protocol::wallet_service::WalletService;
 use testenv::TestEnv;
 use wallet::protocol_wallet_api::MemWallet;
@@ -194,6 +194,30 @@ fn test_redirect() -> anyhow::Result<()> {
 
     let tx = alice.redirect_tx_me.broadcast(&alice.ctx)?;
     dbg!(tx);
+    env.mine_block()?;
+    Ok(())
+}
+
+#[test]
+fn test_custom_payout() -> anyhow::Result<()> {
+    let mut env = TestEnv::new()?;
+    let (alice, bob) = initial_tx_creation(&mut env)?;
+    let mut builder = CustomPayoutTxBuilder::default();
+    builder
+        .set_buyer_input(alice.deposit_tx.builder.buyer_payout()?.clone())
+        .set_seller_input(alice.deposit_tx.builder.seller_payout()?.clone())
+        .set_buyer_input_descriptor(alice.deposit_tx.p_descriptor.clone().unwrap())
+        .set_seller_input_descriptor(alice.deposit_tx.q_descriptor.clone().unwrap())
+        .set_buyer_payout_address(bob.claim_tx_me.builder.payout_address()?.clone())
+        .set_seller_payout_address(alice.claim_tx_me.builder.payout_address()?.clone())
+        .set_seller_payout_amount_excluding_fee(Amount::from_sat(30_000_000))
+        .set_fee_rate(FeeRate::from_sat_per_vb_unchecked(15))
+        .compute_unsigned_tx()?
+        .sign_partial(&alice.ctx.funds)?
+        .sign_partial(&bob.ctx.funds)?;
+    let tx = builder.signed_tx()?;
+
+    dbg!(alice.ctx.funds.transaction_broadcast(&tx)?);
     env.mine_block()?;
     Ok(())
 }

--- a/rpc/src/main/proto/bmp_protocol.proto
+++ b/rpc/src/main/proto/bmp_protocol.proto
@@ -17,7 +17,7 @@ service BmpProtocolService {
   rpc ExecuteRound3(Round3Request) returns (Round3Response);
 
   rpc ExecuteRound4(Round4Request) returns (Round4Response);
-  
+
   rpc ExecuteRound5(Round5Request) returns (google.protobuf.Empty);
 }
 
@@ -35,18 +35,19 @@ message InitializeRequest {
   uint64 buyer_amount_sats = 4;
 }
 
-message InitializeResponse { string trade_id = 1; }
+message InitializeResponse {string trade_id = 1;}
 
-message Round1Request { string trade_id = 1; }
+message Round1Request {string trade_id = 1;}
 
 message Round1Response {
   bytes p_a = 1;                   // Corresponds to musig2::secp::Point
   bytes q_a = 2;                   // Corresponds to musig2::secp::Point
-  bytes dep_part_psbt = 3;         // Corresponds to bdk_wallet::bitcoin::Psbt
-  optional bytes swap_script = 4;  // Optional ScriptBuf
-  bytes warn_anchor_spend = 5;     // ScriptBuf
-  bytes claim_spend = 6;           // ScriptBuf
-  bytes redirect_anchor_spend = 7; // ScriptBuf
+  bytes script_key = 3;            // Corresponds to bdk_wallet::bitcoin::XOnlyPublicKey
+  bytes dep_part_psbt = 4;         // Corresponds to bdk_wallet::bitcoin::Psbt
+  optional bytes swap_script = 5;  // Optional ScriptBuf
+  bytes warn_anchor_spend = 6;     // ScriptBuf
+  bytes claim_spend = 7;           // ScriptBuf
+  bytes redirect_anchor_spend = 8; // ScriptBuf
 }
 
 message Round2Request {
@@ -63,7 +64,7 @@ message Round2Response {
   bytes warn_bob_p_nonce = 6;      // PubNonce
   bytes warn_bob_q_nonce = 7;      // PubNonce
   bytes claim_alice_nonce = 8;     // PubNonce
-  bytes claim_bob_nonce = 9;      // PubNonce
+  bytes claim_bob_nonce = 9;       // PubNonce
   bytes redirect_alice_nonce = 10; // PubNonce
   bytes redirect_bob_nonce = 11;   // PubNonce
 }
@@ -88,10 +89,10 @@ message Round4Request {
 }
 
 message Round4Response {
-    bytes deposit_tx_signed = 1;
+  bytes deposit_tx_signed = 1;
 }
 
 message Round5Request {
-    string trade_id = 1;
-    Round4Response peer_round4_response = 2;
+  string trade_id = 1;
+  Round4Response peer_round4_response = 2;
 }

--- a/rpc/src/pb/bmp_converter.rs
+++ b/rpc/src/pb/bmp_converter.rs
@@ -1,6 +1,5 @@
 use bdk_wallet::bitcoin::ScriptBuf;
 use bdk_wallet::bitcoin::hashes::Hash as _;
-use bdk_wallet::bitcoin::psbt::Psbt;
 use protocol::protocol_musig_adaptor::{self as bmp_engine};
 use tonic::{Result, Status};
 
@@ -10,11 +9,10 @@ use crate::pb::convert::TryProtoInto;
 impl TryProtoInto<bmp_engine::Round1Parameter> for bmp_pb::Round1Response {
     fn try_proto_into(self) -> Result<bmp_engine::Round1Parameter> {
         Ok(bmp_engine::Round1Parameter {
-            p_a: self.p_a.as_slice().try_proto_into()?,
-            q_a: self.q_a.as_slice().try_proto_into()?,
-            dep_part_psbt: Psbt::deserialize(&self.dep_part_psbt).map_err(|e| {
-                Status::invalid_argument(format!("Failed to deserialize Psbt: {e}"))
-            })?,
+            p_a: self.p_a.try_proto_into()?,
+            q_a: self.q_a.try_proto_into()?,
+            script_key: self.script_key.try_proto_into()?,
+            dep_part_psbt: self.dep_part_psbt.try_proto_into()?,
             swap_script: self.swap_script.map(ScriptBuf::from_bytes),
             warn_anchor_spend: ScriptBuf::from_bytes(self.warn_anchor_spend),
             claim_spend: ScriptBuf::from_bytes(self.claim_spend),
@@ -29,6 +27,7 @@ impl TryFrom<bmp_engine::Round1Parameter> for bmp_pb::Round1Response {
         Ok(Self {
             p_a: value.p_a.serialize().to_vec(),
             q_a: value.q_a.serialize().to_vec(),
+            script_key: value.script_key.serialize().to_vec(),
             dep_part_psbt: value.dep_part_psbt.serialize(),
             swap_script: value.swap_script.map(ScriptBuf::into_bytes),
             warn_anchor_spend: value.warn_anchor_spend.into_bytes(),
@@ -60,17 +59,17 @@ impl TryFrom<bmp_engine::Round2Parameter> for bmp_pb::Round2Response {
 impl TryProtoInto<bmp_engine::Round2Parameter> for bmp_pb::Round2Response {
     fn try_proto_into(self) -> Result<bmp_engine::Round2Parameter> {
         Ok(bmp_engine::Round2Parameter {
-            p_agg: self.p_agg.as_slice().try_proto_into()?,
-            q_agg: self.q_agg.as_slice().try_proto_into()?,
-            swap_pub_nonce: self.swap_pub_nonce.as_slice().try_proto_into()?,
-            warn_alice_p_nonce: self.warn_alice_p_nonce.as_slice().try_proto_into()?,
-            warn_alice_q_nonce: self.warn_alice_q_nonce.as_slice().try_proto_into()?,
-            warn_bob_p_nonce: self.warn_bob_p_nonce.as_slice().try_proto_into()?,
-            warn_bob_q_nonce: self.warn_bob_q_nonce.as_slice().try_proto_into()?,
-            claim_alice_nonce: self.claim_alice_nonce.as_slice().try_proto_into()?,
-            claim_bob_nonce: self.claim_bob_nonce.as_slice().try_proto_into()?,
-            redirect_alice_nonce: self.redirect_alice_nonce.as_slice().try_proto_into()?,
-            redirect_bob_nonce: self.redirect_bob_nonce.as_slice().try_proto_into()?,
+            p_agg: self.p_agg.try_proto_into()?,
+            q_agg: self.q_agg.try_proto_into()?,
+            swap_pub_nonce: self.swap_pub_nonce.try_proto_into()?,
+            warn_alice_p_nonce: self.warn_alice_p_nonce.try_proto_into()?,
+            warn_alice_q_nonce: self.warn_alice_q_nonce.try_proto_into()?,
+            warn_bob_p_nonce: self.warn_bob_p_nonce.try_proto_into()?,
+            warn_bob_q_nonce: self.warn_bob_q_nonce.try_proto_into()?,
+            claim_alice_nonce: self.claim_alice_nonce.try_proto_into()?,
+            claim_bob_nonce: self.claim_bob_nonce.try_proto_into()?,
+            redirect_alice_nonce: self.redirect_alice_nonce.try_proto_into()?,
+            redirect_bob_nonce: self.redirect_bob_nonce.try_proto_into()?,
         })
     }
 }
@@ -92,12 +91,12 @@ impl TryFrom<bmp_engine::Round3Parameter> for bmp_pb::Round3Response {
 impl TryProtoInto<bmp_engine::Round3Parameter> for bmp_pb::Round3Response {
     fn try_proto_into(self) -> Result<bmp_engine::Round3Parameter> {
         Ok(bmp_engine::Round3Parameter {
-            deposit_txid: self.deposit_txid.as_slice().try_proto_into()?,
-            swap_part_sig: self.swap_part_sig.as_slice().try_proto_into()?,
-            p_part_peer: self.p_part_peer.as_slice().try_proto_into()?,
-            q_part_peer: self.q_part_peer.as_slice().try_proto_into()?,
-            claim_part_sig: self.claim_part_sig.as_slice().try_proto_into()?,
-            redirect_part_sig: self.redirect_part_sig.as_slice().try_proto_into()?,
+            deposit_txid: self.deposit_txid.try_proto_into()?,
+            swap_part_sig: self.swap_part_sig.try_proto_into()?,
+            p_part_peer: self.p_part_peer.try_proto_into()?,
+            q_part_peer: self.q_part_peer.try_proto_into()?,
+            claim_part_sig: self.claim_part_sig.try_proto_into()?,
+            redirect_part_sig: self.redirect_part_sig.try_proto_into()?,
         })
     }
 }
@@ -114,9 +113,7 @@ impl TryFrom<bmp_engine::Round4Parameter> for bmp_pb::Round4Response {
 impl TryProtoInto<bmp_engine::Round4Parameter> for bmp_pb::Round4Response {
     fn try_proto_into(self) -> Result<bmp_engine::Round4Parameter> {
         Ok(bmp_engine::Round4Parameter {
-            deposit_tx_signed: Psbt::deserialize(&self.deposit_tx_signed).map_err(|e| {
-                Status::invalid_argument(format!("Failed to deserialize Psbt: {e}"))
-            })?,
+            deposit_tx_signed: self.deposit_tx_signed.try_proto_into()?,
         })
     }
 }

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -270,7 +270,7 @@ impl TradeModel {
         let [buyer_pub_key, seller_pub_key] = self.keys.multisig_script_keys()?;
         let [buyer_internal_key, seller_internal_key] = self.keys.internal_keys()?;
 
-        let deposit_merkle_root = script_paths::deposit_payout_merkle_root(buyer_pub_key, seller_pub_key);
+        let deposit_merkle_root = script_paths::deposit_payout_merkle_root(buyer_pub_key, seller_pub_key)?;
         let buyer_payout_tweaked_key_ctx = self.keys.buyer_payout_ctx.with_taproot_tweak(
             Some(&deposit_merkle_root))?;
         let seller_payout_tweaked_key_ctx = self.keys.seller_payout_ctx.with_taproot_tweak(
@@ -281,9 +281,9 @@ impl TradeModel {
             .set_seller_payout_address(seller_payout_tweaked_key_ctx.p2tr_address(network));
         self.custom_payout_tx.builder
             .set_buyer_input_descriptor(script_paths::deposit_payout_descriptor(
-                &buyer_internal_key, buyer_pub_key, seller_pub_key))
+                &buyer_internal_key, buyer_pub_key, seller_pub_key)?)
             .set_seller_input_descriptor(script_paths::deposit_payout_descriptor(
-                &seller_internal_key, buyer_pub_key, seller_pub_key));
+                &seller_internal_key, buyer_pub_key, seller_pub_key)?);
 
         self.buyer_txs.warning.buyer_input_sig_ctx.set_tweaked_key_ctx(buyer_payout_tweaked_key_ctx.clone());
         self.seller_txs.warning.buyer_input_sig_ctx.set_tweaked_key_ctx(buyer_payout_tweaked_key_ctx);
@@ -295,9 +295,9 @@ impl TradeModel {
         let [buyer_claim_merkle_root, seller_claim_merkle_root] = self.keys.claim_key_shares()?
             .map(|p| script_paths::warning_escrow_merkle_root(&p.pub_key().to_public_key().into(), network));
         let buyers_warning_escrow_tweaked_key_ctx = self.keys.seller_payout_ctx.with_taproot_tweak(
-            Some(&buyer_claim_merkle_root))?;
+            Some(&buyer_claim_merkle_root?))?;
         let sellers_warning_escrow_tweaked_key_ctx = self.keys.buyer_payout_ctx.with_taproot_tweak(
-            Some(&seller_claim_merkle_root))?;
+            Some(&seller_claim_merkle_root?))?;
 
         let buyers_warning_escrow_address = buyers_warning_escrow_tweaked_key_ctx.p2tr_address(network);
         let sellers_warning_escrow_address = sellers_warning_escrow_tweaked_key_ctx.p2tr_address(network);

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -14,7 +14,7 @@ use protocol::receiver::{Receiver, ReceiverList};
 use protocol::script_paths;
 use protocol::transaction::{
     CustomPayoutTxBuilder, DepositTxBuilder, ForwardingTxBuilder, NetworkParams as _,
-    RedirectTxBuilder, WarningTxBuilder, WithWitnesses as _,
+    RedirectTxBuilder, TransactionExt as _, WarningTxBuilder,
 };
 use thiserror::Error;
 

--- a/wallet/src/protocol_wallet_api.rs
+++ b/wallet/src/protocol_wallet_api.rs
@@ -110,6 +110,7 @@ impl MemWallet {
         is_selected: &dyn Fn(&OutPoint) -> bool,
     ) -> anyhow::Result<()> {
         let mut psbt_copy = psbt.clone();
+        self.update_psbt_with_derivation_paths(&mut psbt_copy);
         self.wallet.sign(
             &mut psbt_copy,
             SignOptions {
@@ -221,6 +222,41 @@ impl MemWallet {
         env.wait_for_tx(txid).unwrap();
         wallet.sync().unwrap();
         wallet
+    }
+}
+
+pub trait WalletExt {
+    fn update_psbt_with_derivation_paths(&self, psbt: &mut Psbt);
+}
+
+impl WalletExt for Wallet {
+    fn update_psbt_with_derivation_paths(&self, psbt: &mut Psbt) {
+        for input in &mut psbt.inputs {
+            for key in input.tap_key_origins.keys() {
+                let spk = ScriptBuf::new_p2tr(&*LIBSECP256K1_CTX, *key, None);
+                if let Some((keychain, index)) = self.derivation_of_spk(spk) {
+                    let desc = self
+                        .public_descriptor(keychain)
+                        .at_derivation_index(index)
+                        .expect("child can't be hardened");
+                    if let Descriptor::Tr(tr) = desc {
+                        let ik = tr.internal_key();
+                        let pub_key = ik.to_public_key().inner;
+                        let key_source = (
+                            ik.master_fingerprint(),
+                            ik.full_derivation_path().expect("descriptor is definite"),
+                        );
+                        input.bip32_derivation.insert(pub_key, key_source);
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl WalletExt for MemWallet {
+    fn update_psbt_with_derivation_paths(&self, psbt: &mut Psbt) {
+        self.wallet.update_psbt_with_derivation_paths(psbt);
     }
 }
 


### PR DESCRIPTION
Ensure Custom Payout Tx signing works with HD wallet keychains, and not just wallets with a single private key. To this end, add a `protocol_wallet_api::WalletExt` extension trait with a single `update_psbt_with_derivation_paths` method, to help BDK Wallet locate the private keys of any pubkeys found in the tapscripts of the inputs to sign. Without this, the `Wallet::sign` method will only work when the wallet is created from a definite descriptor with a single private key. Update the `sign_selected_inputs` method impls to augment the PSBT metadata with the missing derivation paths, prior to calling `Wallet::sign`.

Also add an integration test to confirm that the signed Custom Payout Txs are broadcastable. This requires updating the protocol implementation in `protocol_musig_adaptor.rs` to exchange multisig script keys (from the traders' respective wallets) with the peer, and adding script paths to the Deposit payout addresses, which were formerly keyspend only. This brings it closer to sync with the protocol implementation in `rpc::protocol` used by the `Musig` gRPC service, which had already been updated similarly in #134.

--

Additionally, make all the `protocol::script_paths::*` public functions return `Result`s, with consistent input validation, to prevent panics in `script_paths::deposit_payout_descriptor` when the buyer & seller multisig keys are identical.

Finally, add a dust limit check to `CustomPayoutTxBuilder` (as well as the other tx builders, which could hypothetically produce dust outputs in the case of very low trade amounts and high tx fees), and ensure that custom payouts pay the correct tx fee even when the payout addresses aren't P2TR (which might occur in the future if they're used to make emergency payouts).

--

This PR hopefully completes the work needed to support mediated custom payouts on the Rust side, leaving just the issue that the BMP wallet code needs to be updated to accept the _external_ private key of the trader's P2TR payout, upon trade completion, instead of the internal key as it does currently.
