### PR TITLE
refactor protocol to use generics instead of trait objects for ProtocolWalletApi and TradeWallet

### DIFF
--- a/protocol/src/protocol_musig_adaptor.rs
+++ b/protocol/src/protocol_musig_adaptor.rs
@@ -10,7 +10,7 @@ use musig2::secp::{MaybeScalar, Point};
 use musig2::{PartialSignature, PubNonce};
 
 use crate::multisig::{KeyCtx, PointExt as _, SigCtx};
-use crate::psbt::BoxedTradeWallet;
+use crate::psbt::TradeWallet;
 use crate::receiver::{Receiver, ReceiverList};
 use crate::script_paths;
 use crate::transaction::{
@@ -87,19 +87,20 @@ pub struct Round4Parameter {
 }
 
 /// this context is for the whole process and need to be persisted by the caller
-pub struct BMPContext {
+pub struct BMPContext<W: TradeWallet> {
     // first of all, everything which is general to the protocol itself.
-    // `funds` is type-erased so the protocol works against any [`TradeWallet`]
-    // implementation (e.g. `MemWallet`, `BMPWallet`, mocks).
-    pub funds: BoxedTradeWallet,
+    // `funds` is the concrete wallet the protocol operates against (e.g. `MemWallet`,
+    // `BMPWallet`, mocks); it is a generic type parameter rather than a trait object so the
+    // protocol stays statically dispatched over the chosen [`TradeWallet`] implementation.
+    pub funds: W,
     pub chain: Box<dyn ChainApi>,
     pub role: ProtocolRole,
     pub seller_amount: Amount,
     pub buyer_amount: Amount,
 }
 
-pub struct BMPProtocol {
-    pub ctx: BMPContext,
+pub struct BMPProtocol<W: TradeWallet> {
+    pub ctx: BMPContext<W>,
     // Point securing Seller deposit and trade amount:
     pub p_tik: KeyCtx,
     // Point securing Buyer deposit:
@@ -118,10 +119,10 @@ pub struct BMPProtocol {
     redirect_tx_peer: RedirectTx,
 }
 
-impl BMPContext {
+impl<W: TradeWallet> BMPContext<W> {
     pub fn new(
         chain: Box<dyn ChainApi>,
-        funds: BoxedTradeWallet,
+        funds: W,
         role: ProtocolRole,
         seller_amount: Amount,
         buyer_amount: Amount,
@@ -135,11 +136,13 @@ impl BMPContext {
         })
     }
 
-    const fn am_buyer(&self) -> bool { matches!(self.role, ProtocolRole::Buyer) }
+    const fn am_buyer(&self) -> bool {
+        matches!(self.role, ProtocolRole::Buyer)
+    }
 }
 
-impl BMPProtocol {
-    pub fn new(ctx: BMPContext) -> anyhow::Result<Self> {
+impl<W: TradeWallet> BMPProtocol<W> {
+    pub fn new(ctx: BMPContext<W>) -> anyhow::Result<Self> {
         let role = ctx.role;
         let [mut p_tik, mut q_tik] = [KeyCtx::default(), KeyCtx::default()];
         p_tik.init_my_key_share();
@@ -399,7 +402,7 @@ impl RedirectTx {
         Ok(())
     }
 
-    pub fn broadcast(&self, me: &BMPContext) -> anyhow::Result<Txid> {
+    pub fn broadcast<W: TradeWallet>(&self, me: &BMPContext<W>) -> anyhow::Result<Txid> {
         me.chain.transaction_broadcast(self.builder.signed_tx()?)
     }
 
@@ -461,7 +464,7 @@ impl ClaimTx {
         Ok(())
     }
 
-    pub fn broadcast(&self, me: &BMPContext) -> anyhow::Result<Txid> {
+    pub fn broadcast<W: TradeWallet>(&self, me: &BMPContext<W>) -> anyhow::Result<Txid> {
         me.chain.transaction_broadcast(self.signed_tx()?)
     }
 }
@@ -497,7 +500,13 @@ impl WarningTx {
         }
     }
 
-    fn build(&mut self, ctx: &mut BMPContext, p_tik: &KeyCtx, q_tik: &KeyCtx, deposit_tx: &DepositTx) -> anyhow::Result<()> {
+    fn build<W: TradeWallet>(
+        &mut self,
+        ctx: &mut BMPContext<W>,
+        p_tik: &KeyCtx,
+        q_tik: &KeyCtx,
+        deposit_tx: &DepositTx,
+    ) -> anyhow::Result<()> {
         self.sig_p.set_tweaked_key_ctx(p_tik.with_taproot_tweak(deposit_tx.merkle_root.as_ref())?);
         self.sig_p.init_my_nonce_share()?;
         self.sig_q.set_tweaked_key_ctx(q_tik.with_taproot_tweak(deposit_tx.merkle_root.as_ref())?);
@@ -553,7 +562,7 @@ impl WarningTx {
         Ok(())
     }
 
-    pub fn broadcast(&self, me: &BMPContext) -> anyhow::Result<Txid> {
+    pub fn broadcast<W: TradeWallet>(&self, me: &BMPContext<W>) -> anyhow::Result<Txid> {
         me.chain.transaction_broadcast(self.signed_tx()?)
     }
 }
@@ -569,9 +578,9 @@ pub struct SwapTx {
 }
 
 impl SwapTx {
-    pub(crate) fn spend_condition(
+    pub(crate) fn spend_condition<W: TradeWallet>(
         &mut self,
-        ctx: &mut BMPContext,
+        ctx: &mut BMPContext<W>,
     ) -> anyhow::Result<Option<ScriptBuf>> {
         self.swap_spend = match self.role {
             ProtocolRole::Seller => Some(ctx.funds.new_address()?.script_pubkey()),
@@ -664,7 +673,7 @@ impl SwapTx {
         Ok(())
     }
 
-    pub fn broadcast(&self, me: &BMPContext) -> anyhow::Result<Txid> {
+    pub fn broadcast<W: TradeWallet>(&self, me: &BMPContext<W>) -> anyhow::Result<Txid> {
         me.chain.transaction_broadcast(self.builder.signed_tx()?)
     }
 }
@@ -684,7 +693,10 @@ impl DepositTx {
 
     fn txid(&self) -> anyhow::Result<Txid> { Ok(*self.builder.txid()?) }
 
-    pub fn generate_part_tx(&mut self, ctx: &mut BMPContext) -> anyhow::Result<Psbt> {
+    pub fn generate_part_tx<W: TradeWallet>(
+        &mut self,
+        ctx: &mut BMPContext<W>,
+    ) -> anyhow::Result<Psbt> {
         self.builder
             .set_trade_amount(ctx.seller_amount - ctx.buyer_amount)
             .set_buyers_security_deposit(ctx.buyer_amount)
@@ -694,19 +706,19 @@ impl DepositTx {
 
         let psbt = if ctx.am_buyer() {
             self.builder
-                .init_buyers_half_psbt(&mut *ctx.funds, &mut rand::rng())?
+                .init_buyers_half_psbt(&mut ctx.funds, &mut rand::rng())?
                 .buyers_half_psbt()?
         } else {
             self.builder
-                .init_sellers_half_psbt(&mut *ctx.funds, &mut rand::rng())?
+                .init_sellers_half_psbt(&mut ctx.funds, &mut rand::rng())?
                 .sellers_half_psbt()?
         };
         Ok(psbt.clone())
     }
 
-    pub fn build_and_merge_tx(
+    pub fn build_and_merge_tx<W: TradeWallet>(
         &mut self,
-        ctx: &mut BMPContext,
+        ctx: &mut BMPContext<W>,
         other_psbt: Psbt,
         p_tik: &KeyCtx,
         q_tik: &KeyCtx,
@@ -718,31 +730,48 @@ impl DepositTx {
         } else {
             self.builder.set_buyers_half_psbt(other_psbt);
         }
-        self.merkle_root = Some(script_paths::deposit_payout_merkle_root(&buyer_pub_key, &seller_pub_key)?);
+        self.merkle_root = Some(script_paths::deposit_payout_merkle_root(
+            &buyer_pub_key,
+            &seller_pub_key,
+        )?);
         self.p_descriptor = Some(script_paths::deposit_payout_descriptor(
-            &p_tik.aggregated_key()?.pub_key().to_public_key().into(), &buyer_pub_key, &seller_pub_key)?);
+            &p_tik.aggregated_key()?.pub_key().to_public_key().into(),
+            &buyer_pub_key,
+            &seller_pub_key,
+        )?);
         self.q_descriptor = Some(script_paths::deposit_payout_descriptor(
-            &q_tik.aggregated_key()?.pub_key().to_public_key().into(), &buyer_pub_key, &seller_pub_key)?);
+            &q_tik.aggregated_key()?.pub_key().to_public_key().into(),
+            &buyer_pub_key,
+            &seller_pub_key,
+        )?);
         let merkle_root = self.merkle_root.as_ref();
         self.builder
-            .set_buyer_payout_address(p_tik.with_taproot_tweak(merkle_root)?.p2tr_address(Network::Regtest))
-            .set_seller_payout_address(q_tik.with_taproot_tweak(merkle_root)?.p2tr_address(Network::Regtest))
+            .set_buyer_payout_address(
+                p_tik
+                    .with_taproot_tweak(merkle_root)?
+                    .p2tr_address(Network::Regtest),
+            )
+            .set_seller_payout_address(
+                q_tik
+                    .with_taproot_tweak(merkle_root)?
+                    .p2tr_address(Network::Regtest),
+            )
             .compute_unsigned_tx()?;
         Ok(())
     }
 
-    fn sign(&mut self, ctx: &mut BMPContext) -> anyhow::Result<()> {
+    fn sign<W: TradeWallet>(&mut self, ctx: &mut BMPContext<W>) -> anyhow::Result<()> {
         if ctx.am_buyer() {
-            self.builder.sign_buyer_inputs(&mut *ctx.funds)?;
+            self.builder.sign_buyer_inputs(&mut ctx.funds)?;
         } else {
-            self.builder.sign_seller_inputs(&mut *ctx.funds)?;
+            self.builder.sign_seller_inputs(&mut ctx.funds)?;
         }
         Ok(())
     }
 
-    fn transfer_sig_and_broadcast(
+    fn transfer_sig_and_broadcast<W: TradeWallet>(
         &mut self,
-        ctx: &mut BMPContext,
+        ctx: &mut BMPContext<W>,
         psbt_bob: Psbt, // bobs psbt should be same as mine but have bob's sig
     ) -> anyhow::Result<Txid> {
         self.builder.combine_psbts(psbt_bob)?;

--- a/protocol/src/psbt.rs
+++ b/protocol/src/psbt.rs
@@ -16,6 +16,7 @@ use musig2::secp::Scalar;
 use rand::{RngCore, SeedableRng as _};
 use rand_chacha::ChaCha20Rng;
 use wallet::bmp_wallet::BMPWallet;
+use wallet::chain_data_source::ChainDataSource;
 use wallet::protocol_wallet_api::{MemWallet, ProtocolWalletApi};
 
 use crate::receiver::Receiver;
@@ -71,11 +72,7 @@ pub trait TradeWallet: ProtocolWalletApi {
     }
 }
 
-/// Type-erased wallet handle used by the trade protocol. The concrete wallet may be a
-/// `MemWallet`, a `BMPWallet<Connection>`, or any other type that implements [`TradeWallet`].
-pub type BoxedTradeWallet = Box<dyn TradeWallet + Send>;
-
-struct MockTradeWallet<Cs: Iterator<Item=TxOutput>, As: Iterator<Item=Address>> {
+pub struct MockTradeWallet<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> {
     funding_coins: Cs,
     new_addresses: As,
     signature_map: BTreeMap<OutPoint, Signature>,
@@ -162,6 +159,10 @@ impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> ProtocolWallet
     fn import_private_key(&mut self, _pk: Scalar) {
         unimplemented!("MockTradeWallet does not support importing private keys")
     }
+
+    fn sync_all<D: ChainDataSource>(&mut self, _data_source: &D) -> anyhow::Result<bool> {
+        unimplemented!("MockTradeWallet does not support sync_all")
+    }
 }
 
 impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> TradeWallet
@@ -238,56 +239,99 @@ impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> TradeWallet
     }
 }
 
+/// Concrete type returned by [`mock_buyer_trade_wallet`] and [`mock_seller_trade_wallet`]. Both
+/// mocks use `Vec`-backed iterators (rather than fixed-size array iterators) so they share a
+/// single concrete type, allowing callers to be statically generic over one `W: TradeWallet`
+/// instead of using `dyn TradeWallet`.
+pub type MockWallet = MockTradeWallet<std::vec::IntoIter<TxOutput>, std::vec::IntoIter<Address>>;
+
 //noinspection SpellCheckingInspection
-pub fn mock_buyer_trade_wallet() -> impl TradeWallet {
-    let funding_coins = [
-        "658654575bbbeb46e965bd9eb37fd3be550a7e0fa2d64bc5f218763155602300:0",
-    ].map(TxOutput::mock_1_btc_coin).into_iter();
-    let signature_map = signature_map(funding_coins.as_slice(), &[
-        "f631ae99b4743315b237af9c48ae1f9bb87b6c5404e84d8e3907269218d1bba5\
+pub fn mock_buyer_trade_wallet() -> MockWallet {
+    let funding_coins = vec!["658654575bbbeb46e965bd9eb37fd3be550a7e0fa2d64bc5f218763155602300:0"]
+        .into_iter()
+        .map(TxOutput::mock_1_btc_coin)
+        .collect::<Vec<_>>()
+        .into_iter();
+    let signature_map = signature_map(
+        funding_coins.as_slice(),
+        &[
+            "f631ae99b4743315b237af9c48ae1f9bb87b6c5404e84d8e3907269218d1bba5\
          4c397158aa233fd3f2227f4dc46922ef62eb8cc39a06b7a339b33e2401d512c1",
-    ]);
-    let new_addresses = [
+        ],
+    );
+    let new_addresses = vec![
         "bcrt1pgsj9aw0wvs5h6zj780djnu267v6jazmfekwm4g4q4s6ax3w3t0lseqqnjc",
         "bcrt1pkar3gerekw8f9gef9vn9xz0qypytgacp9wa5saelpksdgct33qdqan7c89",
         "bcrt1pv537m7m6w0gdrcdn3mqqdpgrk3j400yrdrjwf5c9whyl2f8f4p6q9dn3l9",
         "bcrt1pzvynlely05x82u40cts3znctmvyskue74xa5zwy0t5ueuv92726szpgpaa",
-    ].map(|a| a.parse::<Address<_>>()
-        .expect("hardcoded addresses should be valid").assume_checked()).into_iter();
-    let internal_key =
-        "51494dc22e24a32fe9dcfbd7e85faf345fa1df296fb49d156e859ef345201295".parse().ok();
-    let script_sigs = script_sigs(internal_key.as_slice(), &[
-        "5564448d3c5f024eaf2c65024a0c6e7a9066eb0390f8ffaeee2feacde310fabf\
+    ]
+    .into_iter()
+    .map(|a| {
+        a.parse::<Address<_>>()
+            .expect("hardcoded addresses should be valid")
+            .assume_checked()
+    })
+    .collect::<Vec<_>>()
+    .into_iter();
+    let internal_key = "51494dc22e24a32fe9dcfbd7e85faf345fa1df296fb49d156e859ef345201295"
+        .parse()
+        .ok();
+    let script_sigs = script_sigs(
+        internal_key.as_slice(),
+        &[
+            "5564448d3c5f024eaf2c65024a0c6e7a9066eb0390f8ffaeee2feacde310fabf\
          87f3a8d8ad7fb125d7a6f68a282cfab8cd3178262a1fd0c2d06a598c8c454af8",
-        "652d0abaa3b4f8c7dd85ac9d523d44f768c8e1541aded79165c3cdfb3ba35d62\
+            "652d0abaa3b4f8c7dd85ac9d523d44f768c8e1541aded79165c3cdfb3ba35d62\
          eef114e89becb490a80cfdab946d2d91748ccea501ceb4f08655dcc2868c0463",
-    ]);
+        ],
+    );
 
-    MockTradeWallet { funding_coins, new_addresses, signature_map, internal_key, script_sigs }
+    MockTradeWallet {
+        funding_coins,
+        new_addresses,
+        signature_map,
+        internal_key,
+        script_sigs,
+    }
 }
 
 //noinspection SpellCheckingInspection
-pub fn mock_seller_trade_wallet() -> impl TradeWallet {
-    let funding_coins = [
+pub fn mock_seller_trade_wallet() -> MockWallet {
+    let funding_coins = vec![
         "4a5ecc72ec8db78f11c6785f560a13f6f32eac66d160a8157d30956695ccf523:0",
         "373b3ca0b9135e9649672772d4659bb5597d06b4694f1fbdbece285823fde0a3:1",
-    ].map(TxOutput::mock_1_btc_coin).into_iter();
-    let signature_map = signature_map(funding_coins.as_slice(), &[
-        "2376111ed79dac9ff6f2d85dfe57d142f6075f4df9381aeab87a941477425224\
+    ]
+    .into_iter()
+    .map(TxOutput::mock_1_btc_coin)
+    .collect::<Vec<_>>()
+    .into_iter();
+    let signature_map = signature_map(
+        funding_coins.as_slice(),
+        &[
+            "2376111ed79dac9ff6f2d85dfe57d142f6075f4df9381aeab87a941477425224\
          7555f791ddf82354a3d73fa24955f6c5330ae44b2b238fa74be2eee9a46fcb72",
-        "637f4a624bfc46bdb52e01b923d157a97148210f1a2669716815d3249c615673\
+            "637f4a624bfc46bdb52e01b923d157a97148210f1a2669716815d3249c615673\
          17d543868698f30130e0aaf693ce265c544e3db5eda568bffb6ccd03d25a31df",
-    ]);
-    let new_addresses = [
+        ],
+    );
+    let new_addresses = vec![
         "bcrt1p80xu5f0nqjarfnechsmlt488jf3tykx8cva9zeeczlsu4c7x557qr499gz",
         "bcrt1pt5xd4aqe9whmvlz78mt39rvdlgpp6hujs5ggwan5285zjnsf73rq20k456",
         "bcrt1pwxlp4v9v7v03nx0e7vunlc87d4936wnyqegw0fuahudypan64wysefpqzy",
         "bcrt1pw4s5zvfm665fq9u6uwn9g7gwna658s939dvvf9wg63yede8kvyms5pmalx",
         "bcrt1pe3kcs085e8qej9aqqx6qryv2qsfxzywy9xd8pryzwemv2dghdqgscylr69",
-    ].map(|a| a.parse::<Address<_>>()
-        .expect("hardcoded addresses should be valid").assume_checked()).into_iter();
-    let internal_key =
-        "fcba7ecf41bc7e1be4ee122d9d22e3333671eb0a3a87b5cdf099d59874e1940f".parse().ok();
+    ]
+    .into_iter()
+    .map(|a| {
+        a.parse::<Address<_>>()
+            .expect("hardcoded addresses should be valid")
+            .assume_checked()
+    })
+    .collect::<Vec<_>>()
+    .into_iter();
+    let internal_key = "fcba7ecf41bc7e1be4ee122d9d22e3333671eb0a3a87b5cdf099d59874e1940f"
+        .parse()
+        .ok();
     let script_sigs = script_sigs(internal_key.as_slice(), &[
         "87790f7eb3e98eb1b4dadc55ff5762275c4e3c02c6491abb26c8eabfada55b4b\
          3f2627f627919d667be8f191a1b275b01549ab24e5eeda0019f83c658840500e",

--- a/protocol/tests/protocol_integration_tests.rs
+++ b/protocol/tests/protocol_integration_tests.rs
@@ -7,11 +7,9 @@ use bmp_tracing::tracing;
 use musig2::KeyAggContext;
 use musig2::secp::Point;
 use protocol::protocol_musig_adaptor::{BMPContext, BMPProtocol, ProtocolRole};
-use protocol::psbt::BoxedTradeWallet;
 use protocol::transaction::{CustomPayoutTxBuilder, TransactionExt as _};
 use testenv::TestEnv;
 use wallet::bmp_wallet::{BMPWallet, WalletApi as _};
-use wallet::protocol_wallet_api::MemWallet;
 
 #[test]
 fn test_initial_tx_creation() -> anyhow::Result<()> {
@@ -21,21 +19,12 @@ fn test_initial_tx_creation() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Single entry point used by every test below to obtain a funded trade wallet. The concrete
-/// backend (`MemWallet` vs `BMPWallet<Connection>`) is selected by the `WALLET_BACKEND`
-/// environment variable (`mem` or `bmp`); it defaults to `bmp` when unset. Both implement
-/// [`TradeWallet`] and are interchangeable from the protocol's point of view.
-pub fn funded_wallet(env: &mut TestEnv) -> BoxedTradeWallet {
-    // TODO need to abstract sync(), so we can simplify this.
-    match std::env::var("WALLET_BACKEND")
-        .unwrap_or_else(|_| "bmp".to_owned())
-        .to_ascii_lowercase()
-        .as_str()
-    {
-        "mem" => Box::new(MemWallet::funded_wallet(env)),
-        "bmp" => Box::new(funded_bmp_wallet(env)),
-        other => panic!("unknown WALLET_BACKEND={other:?}, expected `mem` or `bmp`"),
-    }
+/// Single entry point used by every test below to obtain a funded trade wallet. The protocol is
+/// now statically generic over its wallet type, so the tests are pinned to the `BMPWallet`
+/// backend (the previous `WALLET_BACKEND` `mem`/`bmp` switch is gone, since one function can no
+/// longer return two distinct concrete wallet types).
+pub fn funded_wallet(env: &mut TestEnv) -> BMPWallet<Connection> {
+    funded_bmp_wallet(env)
 }
 
 fn funded_bmp_wallet(env: &mut TestEnv) -> BMPWallet<Connection> {
@@ -54,11 +43,11 @@ fn funded_bmp_wallet(env: &mut TestEnv) -> BMPWallet<Connection> {
     wallet
 }
 
-fn initial_tx_creation(env: &mut TestEnv) -> anyhow::Result<(BMPProtocol, BMPProtocol)> {
-    tracing::debug!(
-        "running with wallet backend: {}",
-        std::env::var("WALLET_BACKEND").unwrap_or_else(|_| "bmp (default)".to_owned())
-    );
+/// The trade protocol monomorphized to the `BMPWallet` backend the integration tests use.
+type TradeProtocol = BMPProtocol<BMPWallet<Connection>>;
+
+fn initial_tx_creation(env: &mut TestEnv) -> anyhow::Result<(TradeProtocol, TradeProtocol)> {
+    tracing::debug!("running with wallet backend: bmp");
 
     let alice_funds = funded_wallet(env);
     let bob_funds = funded_wallet(env);
@@ -249,8 +238,8 @@ fn test_custom_payout() -> anyhow::Result<()> {
         .set_seller_payout_amount_excluding_fee(Amount::from_sat(30_000_000))
         .set_fee_rate(FeeRate::from_sat_per_vb_unchecked(15))
         .compute_unsigned_tx()?
-        .sign_partial(&mut *alice.ctx.funds)?
-        .sign_partial(&mut *bob.ctx.funds)?;
+        .sign_partial(&mut alice.ctx.funds)?
+        .sign_partial(&mut bob.ctx.funds)?;
     let tx = builder.signed_tx()?;
 
     dbg!(alice.ctx.chain.transaction_broadcast(&tx)?);

--- a/rpc/src/bmp_service.rs
+++ b/rpc/src/bmp_service.rs
@@ -14,8 +14,9 @@ use crate::pb::convert::TryProtoInto as _;
 
 #[derive(Default)]
 pub struct BmpServiceImpl {
-    // Each trade protocol is stored against a unique ID.
-    active_protocols: Mutex<HashMap<String, BMPProtocol>>,
+    // Each trade protocol is stored against a unique ID. The protocol is generic over its wallet
+    // type; this service pins it to `MemWallet` (the wallet it constructs below).
+    active_protocols: Mutex<HashMap<String, BMPProtocol<MemWallet>>>,
 }
 
 #[tonic::async_trait]
@@ -41,7 +42,7 @@ impl BmpProtocolService for BmpServiceImpl {
 
         let context = BMPContext::new(
             chain,
-            Box::new(mock_wallet),
+            mock_wallet,
             role,
             Amount::from_sat(req.seller_amount_sats),
             Amount::from_sat(req.buyer_amount_sats),

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -9,7 +9,7 @@ use guardian::ArcMutexGuardian;
 use musig2::secp::{MaybeScalar, Point, Scalar};
 use musig2::{PartialSignature, PubNonce};
 use protocol::multisig::{KeyCtx, KeyPair, PointExt as _, SigCtx};
-use protocol::psbt::{self, TradeWallet};
+use protocol::psbt::{self, MockWallet, TradeWallet};
 use protocol::receiver::{Receiver, ReceiverList};
 use protocol::script_paths;
 use protocol::transaction::{
@@ -17,6 +17,7 @@ use protocol::transaction::{
     RedirectTxBuilder, TransactionExt as _, WarningTxBuilder,
 };
 use thiserror::Error;
+use wallet::protocol_wallet_api::ProtocolWalletApi as _;
 
 use crate::storage::{ByRef, ByVal, Storage};
 
@@ -40,11 +41,10 @@ impl TradeModelStore for TradeModelMemoryStore {
 
 pub static TRADE_MODELS: LazyLock<TradeModelMemoryStore> = LazyLock::new(|| Mutex::new(BTreeMap::new()));
 
-#[derive(Default)]
-pub struct TradeModel {
+pub struct TradeModel<W: TradeWallet + Send + 'static = MockWallet> {
     trade_id: String,
     my_role: Role,
-    trade_wallet: Option<Arc<Mutex<dyn TradeWallet + Send + 'static>>>,
+    trade_wallet: Option<Arc<Mutex<W>>>,
     keys: Keys,
     deposit_tx: DepositTx,
     swap_tx: SwapTx,
@@ -53,9 +53,28 @@ pub struct TradeModel {
     seller_txs: ArbitrationTxs,
 }
 
+// `#[derive(Default)]` can't be used on a generic struct without requiring `W: Default`, so the
+// `Default` impl is written by hand (the wallet field defaults to `None`).
+impl<W: TradeWallet + Send + 'static> Default for TradeModel<W> {
+    fn default() -> Self {
+        Self {
+            trade_id: String::default(),
+            my_role: Role::default(),
+            trade_wallet: None,
+            keys: Keys::default(),
+            deposit_tx: DepositTx::default(),
+            swap_tx: SwapTx::default(),
+            custom_payout_tx: CustomPayoutTx::default(),
+            buyer_txs: ArbitrationTxs::default(),
+            seller_txs: ArbitrationTxs::default(),
+        }
+    }
+}
+
 #[derive(Default, Eq, PartialEq)]
 pub enum Role {
-    #[default] SellerAsMaker,
+    #[default]
+    SellerAsMaker,
     SellerAsTaker,
     BuyerAsMaker,
     BuyerAsTaker,
@@ -167,29 +186,44 @@ pub struct ContractualTxids {
     pub sellers_redirect: Txid,
 }
 
-impl TradeModel {
+impl TradeModel<MockWallet> {
     pub fn new(trade_id: String, my_role: Role) -> Self {
-        let mut trade_model = Self { trade_id, my_role, ..Default::default() };
-        let network = trade_model.trade_wallet.insert(if trade_model.am_buyer() {
-            Arc::new(Mutex::new(psbt::mock_buyer_trade_wallet()))
-        } else {
-            Arc::new(Mutex::new(psbt::mock_seller_trade_wallet()))
-        }).lock().unwrap().network();
+        let mut trade_model = Self {
+            trade_id,
+            my_role,
+            ..Default::default()
+        };
+        let network = trade_model
+            .trade_wallet
+            .insert(if trade_model.am_buyer() {
+                Arc::new(Mutex::new(psbt::mock_buyer_trade_wallet()))
+            } else {
+                Arc::new(Mutex::new(psbt::mock_seller_trade_wallet()))
+            })
+            .lock()
+            .unwrap()
+            .network();
         for txs in [&mut trade_model.buyer_txs, &mut trade_model.seller_txs] {
-            txs.warning.builder.set_lock_time(network.warning_lock_time());
-            txs.redirect.builder.set_lock_time(network.redirect_lock_time());
+            txs.warning
+                .builder
+                .set_lock_time(network.warning_lock_time());
+            txs.redirect
+                .builder
+                .set_lock_time(network.redirect_lock_time());
             txs.claim.builder.set_lock_time(network.claim_lock_time());
         }
         trade_model.swap_tx.builder.disable_lock_time();
         trade_model.keys.am_buyer = trade_model.am_buyer();
         trade_model
     }
+}
 
+impl<W: TradeWallet + Send + 'static> TradeModel<W> {
     pub const fn am_buyer(&self) -> bool {
         matches!(self.my_role, Role::BuyerAsMaker | Role::BuyerAsTaker)
     }
 
-    fn trade_wallet(&self) -> Result<ArcMutexGuardian<dyn TradeWallet + Send + 'static>> {
+    fn trade_wallet(&self) -> Result<ArcMutexGuardian<W>> {
         Ok(ArcMutexGuardian::take(self.trade_wallet.clone()
             .ok_or(ProtocolErrorKind::MissingTradeWallet)?).unwrap())
     }

--- a/wallet/src/bmp_wallet.rs
+++ b/wallet/src/bmp_wallet.rs
@@ -356,6 +356,9 @@ impl ProtocolWalletApi for BMPWallet<Connection> {
     fn import_private_key(&mut self, pk: Scalar) {
         self.import_private_key(pk);
     }
+    fn sync_all<D: ChainDataSource>(&mut self, data_source: &D) -> anyhow::Result<bool> {
+        <Self as WalletApi>::sync_all(self, data_source)
+    }
 }
 
 pub trait WalletApi {
@@ -388,7 +391,7 @@ pub trait WalletApi {
         sign_options: SignOptions,
     ) -> anyhow::Result<(), SignerError>;
 
-    fn sync_all(&mut self, data_source: &impl ChainDataSource) -> anyhow::Result<bool>;
+    fn sync_all<D: ChainDataSource>(&mut self, data_source: &D) -> anyhow::Result<bool>;
     fn sync_cbf(
         &mut self,
         scan_type: ScanType,
@@ -640,7 +643,7 @@ impl WalletApi for BMPWallet<Connection> {
         Ok(())
     }
 
-    fn sync_all(&mut self, data_source: &impl ChainDataSource) -> anyhow::Result<bool> {
+    fn sync_all<D: ChainDataSource>(&mut self, data_source: &D) -> anyhow::Result<bool> {
         // 1. Sync the main wallet
         data_source.sync(&mut self.wallet)?;
 

--- a/wallet/src/protocol_wallet_api.rs
+++ b/wallet/src/protocol_wallet_api.rs
@@ -18,6 +18,8 @@ use rand::RngCore;
 use secp::Scalar;
 use thiserror::Error;
 
+use crate::chain_data_source::ChainDataSource;
+
 /// The Protocol Wallet API is used by the protocol to create and sign transactions.
 /// It's the part of functionality being exposed only to the protocol.
 /// The protocol will see `protocol_wallet_api` and the GUI will see `WalletApi`, both are
@@ -54,6 +56,7 @@ pub trait ProtocolWalletApi {
     // Import an external private from the HD wallet
     // After importing a rescan should be triggered
     fn import_private_key(&mut self, pk: Scalar);
+    fn sync_all<D: ChainDataSource>(&mut self, data_source: &D) -> anyhow::Result<bool>;
 }
 pub struct MemWallet {
     wallet: Wallet,
@@ -232,6 +235,9 @@ impl ProtocolWalletApi for MemWallet {
         // If/when this is needed, mirror the `BMPWallet` implementation.
         todo!("MemWallet does not yet support importing private keys")
     }
+    fn sync_all<D: ChainDataSource>(&mut self, _data_source: &D) -> anyhow::Result<bool> {
+        unimplemented!()
+    }
 }
 
 impl ProtocolWalletApi for Wallet {
@@ -280,6 +286,9 @@ impl ProtocolWalletApi for Wallet {
             "bdk_wallet::Wallet does not support importing external private keys; \
             use BMPWallet for that"
         )
+    }
+    fn sync_all<D: ChainDataSource>(&mut self, _data_source: &D) -> anyhow::Result<bool> {
+        unimplemented!()
     }
 }
 


### PR DESCRIPTION
introduced a sync_all method in ProtocolWalletApi to initiate a wallet sync from protocol trade. This was only possible with changing the TradeWallets to be generics instead of trait object. Since Rust prefers generics and there is no real reason to have 2 types of Wallet objects at the same runttime, I converted the 'impl TradeWallet' to generics. The changes look like a lot, but are mainly formatting changes. The real changes are pretty straight forward.

To keep this simple, I changed funded_wallet to return only one type. in more detail:

refactor(protocol): make trade protocol generic over wallet type

  Replace `Box<dyn TradeWallet>` with a static type parameter `W: TradeWallet`
  so the protocol is statically dispatched over its wallet. This is required
  because `ProtocolWalletApi::sync_all<D: ChainDataSource>` is a generic method,
  which makes the trait not dyn-compatible.

  - BMPContext/BMPProtocol become BMPContext<W>/BMPProtocol<W>; thread <W> through the per-tx helper methods. Drop the BoxedTradeWallet alias.
  - Unify mock_buyer/seller_trade_wallet to a single concrete type (MockWallet, backed by Vec iterators) so a generic TradeModel is possible.
  - rpc TradeModel<W = MockWallet> with a default type param; pin bmp_service to BMPProtocol<MemWallet>.
  - Pin integration tests to the BMPWallet backend (drop WALLET_BACKEND switch).