### PR TITLE
Remove cookie fallback to fix standalone musigd execution

### DIFF
--- a/rpc/src/bin/musigd.rs
+++ b/rpc/src/bin/musigd.rs
@@ -20,7 +20,7 @@ struct Cli {
 
     /// Bitcoin Core RPC URL.
     #[arg(long, default_value = "http://localhost:18443")]
-    bitcoin_rpc_url: Option<String>,
+    bitcoin_rpc_url: String,
 
     /// Bitcoin Core RPC username
     #[arg(long)]
@@ -35,24 +35,14 @@ struct Cli {
 async fn main() -> Result<(), Box<dyn Error>> {
     let cli: Cli = Cli::parse();
     bmp_tracing::init("info");
-    // Create or use provided RPC client
-    let rpc_client = if let Some(rpc_url) = &cli.bitcoin_rpc_url {
-        info!(rpc_url, "Connecting to external Bitcoin Core RPC");
-
-        // Determine authentication method
-        let auth = if let (Some(user), Some(pass)) = (&cli.bitcoin_rpc_user, &cli.bitcoin_rpc_pass)
-        {
+    // Create RPC client. (No connection is made at this point.)
+    let rpc_client = {
+        let auth = if let (Some(user), Some(pass)) = (&cli.bitcoin_rpc_user, &cli.bitcoin_rpc_pass) {
             Auth::UserPass(user.clone(), pass.clone())
         } else {
-            // Fall back to the default Bitcoin Core cookie file under the user's home directory.
-            let home = std::env::home_dir()
-                .ok_or("Can't determine home directory for cookie-file fallback; pass --bitcoin-rpc-user/--bitcoin-rpc-pass")?;
-            Auth::CookieFile(home.join(".bitcoin").join(".cookie"))
+            Auth::None
         };
-
-        BitcoinCoreClient::new(rpc_url, auth)?
-    } else {
-        return Err("Can't proceed without bitcoin_rpc_url".into())
+        BitcoinCoreClient::new(&cli.bitcoin_rpc_url, auth)?
     };
 
     let addr = format!("127.0.0.1:{}", cli.port).parse()?;

--- a/rpc/src/bin/musigd.rs
+++ b/rpc/src/bin/musigd.rs
@@ -12,10 +12,7 @@ use tonic::transport::Server;
 
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
-#[expect(
-    clippy::doc_markdown,
-    reason = "doc comments are used verbatim by Clap and not intended to be markdown"
-)]
+#[expect(clippy::doc_markdown, reason = "doc comments are used verbatim by Clap and not intended to be markdown")]
 struct Cli {
     /// The port of the MuSig daemon
     #[arg(short, long, default_value_t = 50051)]
@@ -61,12 +58,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let addr = format!("127.0.0.1:{}", cli.port).parse()?;
     let musig = MusigImpl::default();
     let wallet = WalletImpl {
-        wallet_service: Arc::new(WalletServiceImpl::create_with_rpc_params()),
+        wallet_service: Arc::new(WalletServiceImpl::new()),
     };
-    wallet
-        .wallet_service
-        .clone()
-        .spawn_connection(Arc::new(rpc_client));
+    wallet.wallet_service.clone().spawn_connection(Arc::new(rpc_client));
 
     let bmp_wallet_service = BmpWalletServiceImpl::default();
 

--- a/rpc/src/main/proto/rpc.proto
+++ b/rpc/src/main/proto/rpc.proto
@@ -156,7 +156,7 @@ message CustomPayoutPsbtRequest {
 
 message CustomPayoutPsbt {
   bytes psbt = 1;
-  string txid = 2;
+  string txId = 2;
   uint64 buyersPayoutAmountIncludingFee = 3;  // sats
   uint64 sellersPayoutAmountIncludingFee = 4; // sats
 }

--- a/rpc/src/observable.rs
+++ b/rpc/src/observable.rs
@@ -1,21 +1,18 @@
 use std::borrow::Borrow;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
 use std::hash::Hash;
 
 use futures_util::Stream;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::trace;
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct Observable<T> {
     value: T,
     senders: Vec<mpsc::UnboundedSender<T>>,
 }
 
-#[derive(Debug)]
 struct StillObservedError<T>(Observable<T>);
 
 impl<T> Observable<T> {
@@ -65,7 +62,6 @@ fn shrink_amortized<T>(vec: &mut Vec<T>) {
     }
 }
 
-#[derive(Debug)]
 pub struct ObservableHashMap<K, V> {
     map: HashMap<K, Observable<Option<V>>>,
 }
@@ -122,9 +118,8 @@ impl<K, V> ObservableHashMap<K, V>
 }
 
 impl<K, V> ObservableHashMap<K, V>
-    where
-        K: Clone + Eq + Hash + Debug,
-        V: Clone + PartialEq + Debug,
+    where K: Clone + Eq + Hash,
+          V: Clone + PartialEq
 {
     pub fn sync(&mut self, entries: impl IntoIterator<Item=(K, V)>) {
         let mut remaining_keys: HashSet<K> = self.map.keys().cloned().collect();
@@ -135,8 +130,6 @@ impl<K, V> ObservableHashMap<K, V>
         for key in remaining_keys {
             self.remove(&key);
         }
-        trace!("ObservableHashMap.len {}", self.map.len());
-        // dbg!(&self.map);
     }
 }
 

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -242,7 +242,7 @@ impl musig_server::Musig for MusigImpl {
 
             Ok(CustomPayoutPsbt {
                 psbt: psbt.serialize(),
-                txid: psbt.unsigned_tx.compute_txid().to_string(),
+                tx_id: psbt.unsigned_tx.compute_txid().to_string(),
                 buyers_payout_amount_including_fee: psbt.unsigned_tx.output[0].value.to_sat(),
                 sellers_payout_amount_including_fee: psbt.unsigned_tx.output[1].value.to_sat(),
             })

--- a/rpc/src/wallet.rs
+++ b/rpc/src/wallet.rs
@@ -1,7 +1,4 @@
-#![cfg_attr(
-    feature = "unimock",
-    expect(clippy::ignored_unit_patterns, reason = "macro-generated code")
-)]
+#![cfg_attr(feature = "unimock", expect(clippy::ignored_unit_patterns, reason = "macro-generated code"))]
 
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -26,6 +23,7 @@ const EXTERNAL_DESCRIPTOR: &str = "tr(tprv8ZgxMBicQKsPdrjwWCyXqqJ4YqcyG4DmKtjjsR
 //noinspection SpellCheckingInspection
 const INTERNAL_DESCRIPTOR: &str = "tr(tprv8ZgxMBicQKsPdrjwWCyXqqJ4YqcyG4DmKtjjsRt29v1PtD3r3PuFJAj\
     WytzcvSTKnZAGAkPSmnrdnuHWxCAwy3i1iPhrtKAfXRH7dVCNGp6/86'/1'/0'/1/*)#e3rjrmea";
+const BITCOIND_POLLING_PERIOD: Duration = Duration::from_secs(1);
 
 #[cfg_attr(feature = "unimock", unimock::unimock(api = WalletServiceMock))]
 #[tonic::async_trait]
@@ -42,8 +40,7 @@ pub trait WalletService {
     /// # Panics
     /// Will panic if called outside the context of a Tokio runtime
     fn spawn_connection(self: Arc<Self>, client: Arc<Client>) -> JoinHandle<Result<Never>>
-    where
-        Self: Send + Sync + 'static,
+        where Self: Send + Sync + 'static
     {
         task::spawn(async move {
             self.connect(client).await
@@ -59,16 +56,17 @@ pub struct WalletServiceImpl {
     wallet: RwLock<Wallet>,
     tx_confidence_map: Mutex<ObservableHashMap<Txid, TxConfidence>>,
 
-    // // Make the following RPC parameters configurable for testing:
-    // rpc_client: Client,
+    // Make the following RPC parameters configurable for testing:
     poll_period: Duration,
 }
 
-const BITCOIND_POLLING_PERIOD: Duration = Duration::from_millis(100);
+impl Default for WalletServiceImpl {
+    fn default() -> Self { Self::new() }
+}
 
 impl WalletServiceImpl {
     // TODO: Make wallet setup properly configurable, not just the RPC authentication method and polling period.
-    pub fn create_with_rpc_params() -> Self {
+    pub fn new() -> Self {
         let wallet = Wallet::create(EXTERNAL_DESCRIPTOR, INTERNAL_DESCRIPTOR)
             .network(Network::Regtest)
             .create_wallet_no_persist()
@@ -83,6 +81,9 @@ impl WalletServiceImpl {
             poll_period: BITCOIND_POLLING_PERIOD,
         }
     }
+
+    #[must_use]
+    pub fn with_poll_period(self, poll_period: Duration) -> Self { Self { poll_period, ..self } }
 
     fn sync_tx_confidence_map(&self) {
         let wallet = self.wallet.read().unwrap();

--- a/rpc/tests/bmp_service.rs
+++ b/rpc/tests/bmp_service.rs
@@ -271,7 +271,7 @@ fn spawn_musigd(
 ) -> JoinHandle<Result<(), transport::Error>> {
     let musig = MusigImpl::default();
     let wallet = WalletImpl {
-        wallet_service: Arc::new(WalletServiceImpl::create_with_rpc_params()),
+        wallet_service: Arc::new(WalletServiceImpl::new()),
     };
 
     wallet
@@ -309,7 +309,7 @@ async fn run_musigd_server() -> Result<()> {
         .ok()
         .and_then(|p| p.parse().ok())
         .unwrap_or(50051);
-    
+
     let rpc_url = std::env::var("RPC_URL").ok();
     let electrum_url = std::env::var("ELECTRUM_URL").ok();
     let rpc_pass = Some("bitcoin");
@@ -319,31 +319,30 @@ async fn run_musigd_server() -> Result<()> {
     let rpc_client = rpc_url
         .as_ref()
         .map(|rpc_url| {
-        info!(rpc_url, "Connecting to external Bitcoin Core RPC");
+            info!(rpc_url, "Connecting to external Bitcoin Core RPC");
 
-            let auth = if let (Some(user), Some(pass)) = (&rpc_user, rpc_pass) {
-                Auth::UserPass(user.to_string(), pass.to_owned())
+            let auth = if let (Some(user), Some(pass)) = (rpc_user, rpc_pass) {
+                Auth::UserPass(user.to_owned(), pass.to_owned())
             } else {
                 let home = std::env::var_os("HOME")
-                .map(std::path::PathBuf::from)
-                .expect("Can't determine home directory for cookie-file fallback; set RPC_PASS");
-            Auth::CookieFile(home.join(".bitcoin").join(".cookie"))
-        };
+                    .map(std::path::PathBuf::from)
+                    .expect("Can't determine home directory for cookie-file fallback; set RPC_PASS");
+                Auth::CookieFile(home.join(".bitcoin").join(".cookie"))
+            };
 
             BitcoinCoreClient::new(rpc_url, auth)
-            .expect("Failed to construct Bitcoin Core RPC client")
+                .expect("Failed to construct Bitcoin Core RPC client")
         })
         .expect("RPC_URL must be set");
 
     let listener = TcpListener::bind(("127.0.0.1", port)).await?;
 
-    bmp_tracing::tracing::info!(port, "Starting musigd gRPC server.");
+    info!(port, "Starting musigd gRPC server.");
     let _ = spawn_musigd(
         listener,
         Arc::new(rpc_client),
         electrum_url.unwrap(),
-    )
-    .await;
+    ).await;
 
     Ok(())
 }

--- a/rpc/tests/cli.rs
+++ b/rpc/tests/cli.rs
@@ -103,7 +103,7 @@ async fn test_cli_wallet_balance() {
     let (port, listener) = TestEnv::get_bound_port().await.expect("listener");
     spawn_wallet_grpc_service(
         listener,
-        WalletServiceImpl::create_with_rpc_params(),
+        WalletServiceImpl::new(),
     );
 
     task::spawn_blocking(move || assert_cli_with_port(port, ["wallet-balance"]))
@@ -118,7 +118,7 @@ async fn test_cli_new_address() {
     let (port, listener) = TestEnv::get_bound_port().await.expect("listener");
     spawn_wallet_grpc_service(
         listener,
-        WalletServiceImpl::create_with_rpc_params(),
+        WalletServiceImpl::new(),
     );
 
     task::spawn_blocking(move || assert_cli_with_port(port, ["new-address"]))

--- a/rpc/tests/wallet_service.rs
+++ b/rpc/tests/wallet_service.rs
@@ -30,7 +30,6 @@ async fn test_wallet_service_mine_single_tx() -> Result<()> {
     // Open up a tx confidence stream on the (unconfirmed) paying tx.
     let mut stream = wallet_service.get_tx_confidence_stream(txid);
     let mut expect = stream.next().await;
-    // dbg!(&expect);
     assert!(matches!(expect, Some(Some(TxConfidence { num_confirmations: 0, .. }))));
 
     let balance2 = wallet_service.balance();
@@ -65,7 +64,8 @@ async fn test_wallet_service_mine_single_tx() -> Result<()> {
 }
 
 async fn start_wallet_service(rpc_client: bitcoincore_rpc::Client) -> Arc<impl WalletService> {
-    let wallet_service = Arc::new(WalletServiceImpl::create_with_rpc_params());
+    let wallet_service = Arc::new(WalletServiceImpl::new()
+        .with_poll_period(Duration::from_millis(100)));
     assert_eq!(wallet_service.balance(), Balance::default());
 
     wallet_service


### PR DESCRIPTION
Simplify the code in `musigd.rs`, by removing the cookie fallback when making an RPC connection to bitcoind, as nothing is using `rpc::wallet::WalletService` in production, making password authentication sufficient. Cookie authentication can be added back in when actually needed, but hardcoding the cookie path to `~/.bitcoin/.cookie` is probably not a good idea, as the Regtest bitcoind datadir should live under the project home for the purpose of manual testing, not the user home.

Additionally, this ensures that the `musigd` binary just logs an error on startup instead of aborting, if no command-line arguments are passed and a cookie file cannot be found, since the `BitcoinCoreClient::new` call is now infallible. This restores original behaviour when testing the binary against Bisq2 and `TradeProtocolClient.java`, which presently just use the mocked `Musig` gRPC service and don't require a bitcoind instance.

--

Also fix a Clippy warning in the rpc integration tests, restore 1-second default bitcoin RPC polling interval for production, remove temporary debugging from `rpc::observable` (since that module is already well covered by unit tests), and make some minor formatting changes to the related files.

--

Finally, rename `CustomPayoutPsbt.txid` to `txId` in `rpc.proto` for greater consistency with the rest of the proto and Java/Bisq2 naming conventions.
