### PR TITLE
Update dependencies and cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,10 +302,11 @@ dependencies = [
 
 [[package]]
 name = "bdk_wallet"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d30b5dba770184863b5d966ccbc6a11d12c145450be3b6a4435308297e6a12dc"
+checksum = "c99821af39c7df004bd411ece2ef22d9fba5a631b4489f3d9a0ac0d19637e2d0"
 dependencies = [
+ "anyhow",
  "bdk_chain",
  "bip39",
  "bitcoin",
@@ -313,6 +314,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -1653,13 +1655,12 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "musig2"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c5ffeab912897e7577287c8f2b4efbc4be24912f77531b45ba4b18c93f8be21"
+checksum = "183312a1f782d0e27c2e9aa4d68c151301caa39b38f48ea125c1d55ab1ff29f0"
 dependencies = [
  "base16ct",
  "hmac",
- "once_cell",
  "rand 0.9.4",
  "secp",
  "secp256k1 0.31.1",
@@ -2361,12 +2362,11 @@ dependencies = [
 
 [[package]]
 name = "secp"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b203895e8f18854c828d1cf7e5710683c3abc28d79330fe5ab723ce5b76e1"
+checksum = "e3ef0ffc3b1b2720b00b919f6c697b1e64aca7bba54b93e0ef4b8560fac6f946"
 dependencies = [
  "base16ct",
- "once_cell",
  "rand 0.9.4",
  "secp256k1 0.31.1",
  "subtle",
@@ -3379,9 +3379,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zeromq"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32e1e46c4e278efd0c1153f2db0113924b9bc5fff9f9221853d035e2d26fadf"
+checksum = "efb2c254fd8f366755335c9e43b865f8484fe3bd717d65ffe7c3f28852863030"
 dependencies = [
  "async-trait",
  "asynchronous-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "argon2"
@@ -108,15 +108,15 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -159,15 +159,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -214,12 +214,11 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+checksum = "365c0acd5b2e8dd0111a46c4faea83fb3cfb6e39a49a7c73a06e090db7b2eff0"
 dependencies = [
- "bitcoin-internals 0.3.0",
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.101",
 ]
 
 [[package]]
@@ -343,7 +342,7 @@ dependencies = [
  "bitcoin",
  "bitcoin_hashes 0.15.0",
  "chacha20-poly1305",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
 ]
 
@@ -353,24 +352,23 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.101",
  "serde",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "bitcoin"
-version = "0.32.8"
+version = "0.32.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
  "bech32",
- "bitcoin-internals 0.3.0",
- "bitcoin-io 0.1.4",
+ "bitcoin-io 0.1.101",
  "bitcoin-units",
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.101",
  "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1 0.29.1",
@@ -387,12 +385,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
+name = "bitcoin-consensus-encoding"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
 dependencies = [
- "serde",
+ "bitcoin-internals 0.5.0",
 ]
 
 [[package]]
@@ -402,10 +400,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90bbbfa552b49101a230fb2668f3f9ef968c81e6f83cf577e1d4b80f689e1aa"
 
 [[package]]
-name = "bitcoin-io"
-version = "0.1.4"
+name = "bitcoin-internals"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
+dependencies = [
+ "hex-conservative 0.3.2",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
 
 [[package]]
 name = "bitcoin-io"
@@ -418,21 +428,21 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.2"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
 dependencies = [
- "bitcoin-internals 0.3.0",
+ "bitcoin-consensus-encoding",
  "serde",
 ]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
- "bitcoin-io 0.1.4",
+ "bitcoin-io 0.1.101",
  "hex-conservative 0.2.2",
  "serde",
 ]
@@ -479,9 +489,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blake2"
@@ -520,21 +530,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.1"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -544,9 +563,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bzip2"
@@ -570,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -606,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -618,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -640,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -664,11 +683,12 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -709,7 +729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "768391062ec3812e223bb3031c5b2fcdd6e0e60b816157f21df82fd3e6617dc0"
 dependencies = [
  "anyhow",
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.101",
  "corepc-client",
  "flate2",
  "log",
@@ -782,7 +802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.31.3",
  "windows-sys 0.61.2",
 ]
 
@@ -826,7 +846,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -859,7 +878,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -883,9 +902,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "electrsd"
@@ -893,7 +912,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8926868af723c2819807809e54585992aaea0e26a6f5089ac8c2598eaec8d01"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.101",
  "corepc-client",
  "corepc-node",
  "electrum-client",
@@ -913,7 +932,7 @@ dependencies = [
  "byteorder",
  "libc",
  "log",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "serde",
  "serde_json",
  "webpki-roots",
@@ -950,19 +969,18 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1131,15 +1149,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1150,9 +1166,9 @@ checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1160,7 +1176,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1194,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1265,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1310,9 +1326,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1388,12 +1404,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,12 +1422,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1445,11 +1455,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -1466,34 +1477,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
-
-[[package]]
-name = "libredox"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
-dependencies = [
- "bitflags 2.11.0",
- "libc",
- "plain",
- "redox_syscall 0.7.3",
-]
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1523,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -1573,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -1594,9 +1602,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniscript"
-version = "12.3.5"
+version = "12.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487906208f38448e186e3deb02f2b8ef046a9078b0de00bdb28bf4fb9b76951c"
+checksum = "b8343cc1ef1408bd9bdbf69f7aef47017dfab7e6349ec26fddf62e0e9fb5a4cf"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1628,9 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1652,7 +1660,7 @@ dependencies = [
  "base16ct",
  "hmac",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "secp",
  "secp256k1 0.31.1",
  "sha2",
@@ -1681,11 +1689,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1708,9 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1766,7 +1774,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -1791,23 +1799,23 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1828,15 +1836,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polonius-the-crab"
@@ -1924,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1934,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
  "itertools",
@@ -1955,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1968,9 +1970,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
@@ -1986,7 +1988,7 @@ dependencies = [
  "const_format",
  "musig2",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "testenv",
  "thiserror 2.0.18",
@@ -1996,11 +1998,11 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "memchr",
  "unicase",
 ]
@@ -2016,9 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2037,9 +2039,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2048,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2100,16 +2102,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2134,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2157,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ring"
@@ -2195,7 +2188,7 @@ dependencies = [
  "predicates",
  "prost",
  "protocol",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rpc",
  "serde",
  "serde_with",
@@ -2217,7 +2210,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2231,7 +2224,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2252,24 +2245,24 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
@@ -2286,9 +2279,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2303,15 +2296,15 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "saa"
-version = "5.5.0"
+version = "5.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c7f49c9d5caa3bf4b3106900484b447b9253fe99670ceb81cb6cb5027855e1"
+checksum = "68f5acb362a0e75c2a963532fa7fabf13dff81626dc494df16488d30befcbea0"
 
 [[package]]
 name = "scc"
-version = "3.6.12"
+version = "3.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f448f7d881535036452f0cac656a41463807f095eda504890764ca7d11e2a2ea"
+checksum = "5581cd5dd2cb79cbe9d8137071d67f62f0db926e83a07b4d14561c5b7d423776"
 dependencies = [
  "saa",
  "sdd",
@@ -2359,9 +2352,12 @@ dependencies = [
 
 [[package]]
 name = "sdd"
-version = "4.7.5"
+version = "4.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ca0e33fc1ae39e36b2d1fdfc8ee470b26397b642ff87572a59a36ff4f2340b"
+checksum = "1836bad8bdc9c6d665b63202da3d9c6d60ed1e597cae63620e21ebf89a3595a9"
+dependencies = [
+ "saa",
+]
 
 [[package]]
 name = "secp"
@@ -2371,7 +2367,7 @@ checksum = "0d3b203895e8f18854c828d1cf7e5710683c3abc28d79330fe5ab723ce5b76e1"
 dependencies = [
  "base16ct",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "secp256k1 0.31.1",
  "subtle",
 ]
@@ -2382,8 +2378,8 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.1",
- "rand 0.8.5",
+ "bitcoin_hashes 0.14.101",
+ "rand 0.8.6",
  "secp256k1-sys 0.10.1",
  "serde",
 ]
@@ -2394,8 +2390,8 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
- "bitcoin_hashes 0.14.1",
- "rand 0.9.2",
+ "bitcoin_hashes 0.14.101",
+ "rand 0.9.4",
  "secp256k1-sys 0.11.0",
 ]
 
@@ -2416,12 +2412,6 @@ checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -2455,9 +2445,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2468,15 +2458,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -2487,9 +2478,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2519,9 +2510,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2547,15 +2538,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2575,9 +2566,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2592,9 +2583,9 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -2608,7 +2599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2635,9 +2626,8 @@ dependencies = [
  "electrsd",
  "hex",
  "hmac",
- "rand 0.9.2",
+ "rand 0.9.4",
  "secp",
- "serde_json",
  "sha2",
  "tempfile",
  "tokio",
@@ -2695,12 +2685,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2710,15 +2699,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2741,9 +2730,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2758,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2794,9 +2783,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -2823,9 +2812,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2835,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -2846,9 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2868,7 +2857,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -2966,9 +2955,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -3034,11 +3023,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -3083,7 +3072,7 @@ dependencies = [
  "bmp_tracing",
  "chain",
  "hex",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rusqlite",
  "secp",
  "tempfile",
@@ -3110,27 +3099,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3141,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3151,9 +3131,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3164,45 +3144,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.13.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver",
 ]
 
 [[package]]
@@ -3385,91 +3331,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.13.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "xattr"
@@ -3489,18 +3353,18 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3509,9 +3373,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zeromq"
@@ -3528,7 +3392,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "scc",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["chain", "protocol", "rpc", "wallet", "testenv", "bmp_tracing", "mem"]
 
 [workspace.dependencies]
-anyhow = "1.0.102"
+anyhow = "1.0.103"
 argon2 = { version = "0.5.3", default-features = false }
 base64 = "0.22.1"
 bdk_bitcoind_rpc = "0.22.0"
@@ -13,21 +13,25 @@ bdk_kyoto = "0.15.4"
 bdk_wallet = { version = "~2.1.0", features = ["rusqlite", "keys-bip39"] }
 bmp_tracing = { path = "bmp_tracing" }
 chain = { path = "chain" }
-const_format = "0.2.35"
+clap = { version = "4.6.1", features = ["derive"] }
+const_format = "0.2.36"
 hex = "0.4.3"
 musig2 = { version = "0.3.1", features = ["rand"] }
-rand = "0.9.2"
+protocol = { path = "protocol" }
+rand = "0.9.4"
 rand_chacha = "0.9.0"
 rusqlite = { version = "0.31.0", features = ["bundled-sqlcipher"] }
 secp = "0.6.0"
 tempfile = "3.27.0"
+testenv = { path = "testenv" }
 thiserror = "2.0.18"
-tokio = "1.50.0"
+tokio = "1.52.3"
 tokio-stream = "0.1.18"
 tracing = "0.1.44"
 tracing-core = { version = "0.1.36", default-features = false }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
-zeroize = "1.8.2"
+wallet = { path = "wallet" }
+zeroize = "1.9.0"
 
 [workspace.lints.rust]
 rust-2024-compatibility = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,19 +9,18 @@ base64 = "0.22.1"
 bdk_bitcoind_rpc = "0.22.0"
 bdk_electrum = { version = "0.23.2", default-features = false, features = ["use-rustls-ring"] }
 bdk_kyoto = "0.15.4"
-# v2.2.0 deprecates `bdk_wallet::wallet::signer` without making it clear what alternative to use & how:
-bdk_wallet = { version = "~2.1.0", features = ["rusqlite", "keys-bip39"] }
+bdk_wallet = { version = "2.4.0", features = ["rusqlite", "keys-bip39"] }
 bmp_tracing = { path = "bmp_tracing" }
 chain = { path = "chain" }
 clap = { version = "4.6.1", features = ["derive"] }
 const_format = "0.2.36"
 hex = "0.4.3"
-musig2 = { version = "0.3.1", features = ["rand"] }
+musig2 = { version = "0.4.1", features = ["rand"] }
 protocol = { path = "protocol" }
 rand = "0.9.4"
 rand_chacha = "0.9.0"
 rusqlite = { version = "0.31.0", features = ["bundled-sqlcipher"] }
-secp = "0.6.0"
+secp = "0.7.0"
 tempfile = "3.27.0"
 testenv = { path = "testenv" }
 thiserror = "2.0.18"

--- a/bmp_tracing/src/lib.rs
+++ b/bmp_tracing/src/lib.rs
@@ -4,13 +4,12 @@ use std::io;
 use std::path::PathBuf;
 use std::sync::{Mutex, PoisonError};
 
-pub use tracing;
-pub use tracing_subscriber;
 use tracing_subscriber::filter::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::util::SubscriberInitExt as _;
 use tracing_subscriber::{Layer, fmt};
+pub use {tracing, tracing_subscriber};
 
 #[derive(Debug, Clone)]
 #[expect(clippy::exhaustive_enums)]

--- a/mem/Cargo.toml
+++ b/mem/Cargo.toml
@@ -4,15 +4,15 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
-zeromq = { version = "0.5", default-features = false, features = ["tokio-runtime", "tcp-transport"] }
 anyhow = { workspace = true }
 bdk_wallet = { workspace = true }
 hex = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 tokio-stream = { workspace = true }
+zeromq = { version = "0.5", default-features = false, features = ["tokio-runtime", "tcp-transport"] }
 
 [dev-dependencies]
-testenv = { path = "../testenv" }
+testenv = { workspace = true }
 
 [lints]
 workspace = true

--- a/mem/Cargo.toml
+++ b/mem/Cargo.toml
@@ -9,7 +9,7 @@ bdk_wallet = { workspace = true }
 hex = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 tokio-stream = { workspace = true }
-zeromq = { version = "0.5", default-features = false, features = ["tokio-runtime", "tcp-transport"] }
+zeromq = { version = "0.6", default-features = false, features = ["tokio-runtime", "tcp-transport"] }
 
 [dev-dependencies]
 testenv = { workspace = true }

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -6,21 +6,20 @@ edition = "2024"
 [dependencies]
 anyhow = { workspace = true }
 bdk_wallet = { workspace = true }
+chain = { workspace = true }
 musig2 = { workspace = true }
 paste = "1.0.15"
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-chain = { workspace = true }
-# TODO move this to dev-dependencies:
-testenv = { path = "../testenv" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-wallet = { path = "../wallet" }
+wallet = { workspace = true }
 
 [dev-dependencies]
 bdk_wallet = { workspace = true, features = ["test-utils"] }
 bmp_tracing = { workspace = true }
 const_format = { workspace = true }
+testenv = { workspace = true }
 
 [lints]
 workspace = true

--- a/protocol/src/multisig.rs
+++ b/protocol/src/multisig.rs
@@ -48,9 +48,9 @@ struct NoncePair {
 }
 
 impl NoncePair {
-    fn new(nonce_seed: impl Into<NonceSeed>, aggregated_pub_key: Point) -> Self {
-        let sec_nonce = SecNonceBuilder::new(nonce_seed)
-            .with_aggregated_pubkey(aggregated_pub_key)
+    fn new(nonce_seed: impl Into<NonceSeed>, seckey: Scalar, aggregated_pubkey: Point) -> Self {
+        let sec_nonce = SecNonceBuilder::from_seckey(nonce_seed, seckey)
+            .with_aggregated_pubkey(aggregated_pubkey)
             .build();
         Self { pub_nonce: sec_nonce.public_nonce(), sec_nonce: Some(sec_nonce) }
     }
@@ -220,10 +220,11 @@ impl SigCtx {
     }
 
     pub fn init_my_nonce_share(&mut self) -> Result<()> {
-        let aggregated_pub_key = self.tweaked_key_ctx()?.key_agg_ctx.aggregated_pubkey();
+        let seckey = self.tweaked_key_ctx()?.my_prv_key;
+        let aggregated_pubkey = self.tweaked_key_ctx()?.key_agg_ctx.aggregated_pubkey();
         // TODO: Consider making the RNG configurable, to aid unit testing:
         self.my_nonce_pair_share.get_or_insert_with(||
-            NoncePair::new(&mut rand::rng(), aggregated_pub_key));
+            NoncePair::new(&mut rand::rng(), seckey, aggregated_pubkey));
         Ok(())
     }
 

--- a/protocol/src/protocol_musig_adaptor.rs
+++ b/protocol/src/protocol_musig_adaptor.rs
@@ -363,7 +363,7 @@ impl RedirectTx {
         self.sig.init_my_nonce_share()?;
 
         let receiver_shares = Self::get_dao_bm();
-        let fee_rate = FeeRate::from_sat_per_vb_unchecked(10); // TODO: feerates shall come from pricenodes
+        let fee_rate = FeeRate::from_sat_per_vb_u32(10); // TODO: feerates shall come from pricenodes
 
         let escrow_amount = warn_tx.builder.escrow()?.prevout.value;
         let available_amount_msat = RedirectTxBuilder::available_amount_msat(escrow_amount, fee_rate)?;
@@ -438,7 +438,7 @@ impl ClaimTx {
             .set_input(warn_tx.builder.escrow()?)
             .set_payout_address(Address::from_script(self.claim_spend.as_ref().unwrap(), Network::Regtest)?) // TODO: Improve.
             .set_lock_time(t2)
-            .set_fee_rate(FeeRate::from_sat_per_vb_unchecked(10)) // TODO: feerates shall come from pricenodes
+            .set_fee_rate(FeeRate::from_sat_per_vb_u32(10)) // TODO: feerates shall come from pricenodes
             .compute_unsigned_tx()?;
         Ok(())
     }
@@ -515,7 +515,7 @@ impl WarningTx {
             .set_escrow_address(key_spend.p2tr_address(Network::Regtest))
             .set_anchor_address(Address::from_script(self.anchor_spend.as_ref().unwrap(), Network::Regtest)?) // TODO: Improve.
             .set_lock_time(relative::LockTime::ZERO)
-            .set_fee_rate(FeeRate::from_sat_per_vb_unchecked(10)) // TODO: feerates shall come from pricenodes
+            .set_fee_rate(FeeRate::from_sat_per_vb_u32(10)) // TODO: feerates shall come from pricenodes
             .compute_unsigned_tx()?
             .txid()?;
 
@@ -614,7 +614,7 @@ impl SwapTx {
             .set_input(deposit_tx.builder.seller_payout()?.clone())
             .set_payout_address(Address::from_script(use_spend, Network::Regtest)?) // TODO: Improve.
             .disable_lock_time()
-            .set_fee_rate(FeeRate::from_sat_per_vb_unchecked(10)) // TODO: feerates shall come from pricenodes
+            .set_fee_rate(FeeRate::from_sat_per_vb_u32(10)) // TODO: feerates shall come from pricenodes
             .compute_unsigned_tx()?;
         Ok(())
     }
@@ -690,7 +690,7 @@ impl DepositTx {
             .set_buyers_security_deposit(ctx.buyer_amount)
             .set_sellers_security_deposit(ctx.buyer_amount)
             .set_trade_fee_receivers(ReceiverList::default())
-            .set_fee_rate(FeeRate::from_sat_per_vb_unchecked(20)); // TODO: feerates shall come from pricenodes
+            .set_fee_rate(FeeRate::from_sat_per_vb_u32(20)); // TODO: feerates shall come from pricenodes
 
         let psbt = if ctx.am_buyer() {
             self.builder

--- a/protocol/src/psbt.rs
+++ b/protocol/src/psbt.rs
@@ -83,9 +83,7 @@ struct MockTradeWallet<Cs: Iterator<Item=TxOutput>, As: Iterator<Item=Address>> 
     script_sigs: BTreeMap<XOnlyPublicKey, Vec<Signature>>,
 }
 
-impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> ProtocolWalletApi
-    for MockTradeWallet<Cs, As>
-{
+impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item=Address>> ProtocolWalletApi for MockTradeWallet<Cs, As> {
     fn network(&self) -> Network { Network::Regtest }
 
     fn new_address(&mut self) -> anyhow::Result<Address> {
@@ -118,12 +116,8 @@ impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> ProtocolWallet
     ) -> anyhow::Result<()> {
         let mut script_sigs = self.script_sigs.clone();
 
-        for (
-            input,
-            TxIn {
-                previous_output, ..
-            },
-        ) in psbt.inputs.iter_mut().zip(&psbt.unsigned_tx.input)
+        for (input, TxIn { previous_output, .. })
+        in psbt.inputs.iter_mut().zip(&psbt.unsigned_tx.input)
         {
             if is_selected(previous_output) {
                 for (key, (leaf_hashes, _)) in &input.tap_key_origins {
@@ -164,9 +158,7 @@ impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> ProtocolWallet
     }
 }
 
-impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> TradeWallet
-    for MockTradeWallet<Cs, As>
-{
+impl<Cs: Iterator<Item=TxOutput>, As: Iterator<Item=Address>> TradeWallet for MockTradeWallet<Cs, As> {
     fn create_half_deposit_psbt(
         &mut self,
         deposit_amount: Amount,

--- a/protocol/src/psbt.rs
+++ b/protocol/src/psbt.rs
@@ -75,7 +75,7 @@ pub trait TradeWallet: ProtocolWalletApi {
 /// `MemWallet`, a `BMPWallet<Connection>`, or any other type that implements [`TradeWallet`].
 pub type BoxedTradeWallet = Box<dyn TradeWallet + Send>;
 
-struct MockTradeWallet<Cs: Iterator<Item=TxOutput>, As: Iterator<Item=Address>> {
+struct MockTradeWallet<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> {
     funding_coins: Cs,
     new_addresses: As,
     signature_map: BTreeMap<OutPoint, Signature>,
@@ -83,7 +83,7 @@ struct MockTradeWallet<Cs: Iterator<Item=TxOutput>, As: Iterator<Item=Address>> 
     script_sigs: BTreeMap<XOnlyPublicKey, Vec<Signature>>,
 }
 
-impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item=Address>> ProtocolWalletApi for MockTradeWallet<Cs, As> {
+impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> ProtocolWalletApi for MockTradeWallet<Cs, As> {
     fn network(&self) -> Network { Network::Regtest }
 
     fn new_address(&mut self) -> anyhow::Result<Address> {
@@ -158,7 +158,7 @@ impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item=Address>> ProtocolWalletAp
     }
 }
 
-impl<Cs: Iterator<Item=TxOutput>, As: Iterator<Item=Address>> TradeWallet for MockTradeWallet<Cs, As> {
+impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> TradeWallet for MockTradeWallet<Cs, As> {
     fn create_half_deposit_psbt(
         &mut self,
         deposit_amount: Amount,

--- a/protocol/src/psbt.rs
+++ b/protocol/src/psbt.rs
@@ -557,7 +557,7 @@ mod tests {
         let mut rng = rand::rng();
 
         let deposit_amount = Amount::from_sat(40_000);
-        let fee_rate = FeeRate::from_sat_per_vb_unchecked(10);
+        let fee_rate = FeeRate::from_sat_per_vb_u32(10);
         let receiver_address = "bcrt1qwk6p86mzqmstcsg99qlu2mhsp3766u68jktv6k"
             .parse::<Address<_>>()?.require_network(Network::Regtest)?;
         let trade_fee_receivers = [

--- a/protocol/src/receiver.rs
+++ b/protocol/src/receiver.rs
@@ -156,7 +156,7 @@ mod tests {
     fn test_compute_receivers_from_shares_none_filtered() {
         // These are the same available msat amount, fee rate & absolute receiver amounts used in
         // the test trades of 'rpc/src/main/java/bisq/TradeProtocolClient.java'.
-        let fee_rate = FeeRate::from_sat_per_vb_unchecked(10);
+        let fee_rate = FeeRate::from_sat_per_vb_u32(10);
         let available_amount_msat = 256_115_000;
 
         // (The precise fractions chosen here sum to unity and exercise the use of `f64::round` in
@@ -213,7 +213,7 @@ mod tests {
     //noinspection SpellCheckingInspection
     #[test]
     fn test_compute_receivers_from_shares_one_filtered_by_min_output_saturation() {
-        let fee_rate = FeeRate::from_sat_per_vb_unchecked(10);
+        let fee_rate = FeeRate::from_sat_per_vb_u32(10);
         // 1999 sats for two P2TR outputs, plus 860 sats for their fee contributions:
         let available_amount_msat = 2_859_000;
 
@@ -242,7 +242,7 @@ mod tests {
     //noinspection SpellCheckingInspection
     #[test]
     fn test_compute_receivers_from_shares_all_filtered() {
-        let fee_rate = FeeRate::from_sat_per_vb_unchecked(10);
+        let fee_rate = FeeRate::from_sat_per_vb_u32(10);
         // 999 sats for one P2TR output, plus 430 sats for its fee contribution:
         let available_amount_msat = 1_429_000;
 
@@ -262,7 +262,7 @@ mod tests {
     //noinspection SpellCheckingInspection
     #[test]
     fn test_compute_receivers_from_shares_more_than_251_outputs() {
-        let fee_rate = FeeRate::from_sat_per_vb_unchecked(1);
+        let fee_rate = FeeRate::from_sat_per_vb_u32(1);
         // 10_000 sats each for 252 P2SH outputs, 8_064 = 252 * 32 sats for their fee contributions,
         // but this _doesn't_ include the extra 2 vB <-> 2 sats cost for including >251 outputs:
         let mut available_amount_msat = 2_528_064_000;

--- a/protocol/src/transaction.rs
+++ b/protocol/src/transaction.rs
@@ -1036,7 +1036,7 @@ mod tests {
             .set_buyer_payout_address(buyer_payout_address)
             .set_seller_payout_address(seller_payout_address)
             .set_seller_payout_amount_excluding_fee(Amount::from_sat(30_000_000))
-            .set_fee_rate(FeeRate::from_sat_per_vb_unchecked(15))
+            .set_fee_rate(FeeRate::from_sat_per_vb_u32(15))
             .compute_unsigned_tx()?;
         Ok(builder)
     }

--- a/protocol/src/transaction.rs
+++ b/protocol/src/transaction.rs
@@ -380,7 +380,7 @@ impl WarningTxBuilder {
     make_getter!(signed_tx: Transaction);
     make_getter!(txid: Txid: Transaction);
 
-    pub fn escrow_amount(input_amounts: impl IntoIterator<Item=Amount>, fee_rate: FeeRate) -> Result<Amount> {
+    pub fn escrow_amount(input_amounts: impl IntoIterator<Item = Amount>, fee_rate: FeeRate) -> Result<Amount> {
         (|| input_amounts.into_iter().checked_sum()?
             .checked_sub(ANCHOR_AMOUNT)?
             .checked_sub(fee_rate.checked_mul_by_weight(SIGNED_WARNING_TX_WEIGHT)?)
@@ -593,7 +593,7 @@ impl CustomPayoutTxBuilder {
     make_getter!(psbt: Psbt: Transaction);
 
     fn payout_amounts(
-        input_amounts: impl IntoIterator<Item=Amount>,
+        input_amounts: impl IntoIterator<Item = Amount>,
         seller_payout_amount_excluding_fee: Amount,
         signed_tx_weight: Weight,
         fee_rate: FeeRate,

--- a/protocol/tests/protocol_integration_tests.rs
+++ b/protocol/tests/protocol_integration_tests.rs
@@ -247,7 +247,7 @@ fn test_custom_payout() -> anyhow::Result<()> {
         .set_buyer_payout_address(bob.claim_tx_me.builder.payout_address()?.clone())
         .set_seller_payout_address(alice.claim_tx_me.builder.payout_address()?.clone())
         .set_seller_payout_amount_excluding_fee(Amount::from_sat(30_000_000))
-        .set_fee_rate(FeeRate::from_sat_per_vb_unchecked(15))
+        .set_fee_rate(FeeRate::from_sat_per_vb_u32(15))
         .compute_unsigned_tx()?
         .sign_partial(&mut *alice.ctx.funds)?
         .sign_partial(&mut *bob.ctx.funds)?;

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -13,35 +13,35 @@ drop-stream = "0.3.2"
 futures-util = { version = "0.3.32", default-features = false, features = ["alloc"] }
 guardian = "1.3.0"
 musig2 = { workspace = true }
-prost = "0.14.3"
-protocol = { path = "../protocol" }
+prost = "0.14.4"
+protocol = { workspace = true }
 rand = { workspace = true }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_with = { version = "3.18.0", features = ["base64", "hex"] }
+serde_with = { version = "3.21.0", features = ["base64", "hex"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 tokio-stream = { workspace = true }
-tonic = "0.14.5"
-tonic-prost = "0.14.5"
+tonic = "0.14.6"
+tonic-prost = "0.14.6"
 tracing = { workspace = true }
 unimock = { version = "0.6.8", optional = true }
 # Dependencies used only by the binary target(s):
 # TODO: Consider making a workspace of separate packages to avoid pulling these into the library:
 bmp_tracing = { workspace = true }
-clap = { version = "4.6.0", features = ["derive"] }
-wallet = { path = "../wallet" }
+clap = { workspace = true }
+wallet = { workspace = true }
 
 [build-dependencies]
-tonic-prost-build = "0.14.5"
+tonic-prost-build = "0.14.6"
 
 [dev-dependencies]
 rpc = { path = ".", features = ["unimock"] }
-assert_cmd = "2.2.0"
+assert_cmd = "2.2.2"
+bdk_electrum = { workspace = true }
+chain = { workspace = true }
 const_format = { workspace = true }
 predicates = "3.1.4"
-testenv = { path = "../testenv" }
-chain = { workspace = true }
-bdk_electrum = { workspace = true }
+testenv = { workspace = true }
 
 [lints]
 workspace = true

--- a/rpc/src/observable.rs
+++ b/rpc/src/observable.rs
@@ -30,7 +30,7 @@ impl<T> Observable<T> {
 impl<T: Clone> Observable<T> {
     #[expect(impl_trait_overcaptures,
     reason = "need to append `+ use<T>` to get correct semantics with Rust 2024 (but breaks IDE)")]
-    pub fn observe(&mut self) -> impl Stream<Item=T> { // + use<T> {
+    pub fn observe(&mut self) -> impl Stream<Item = T> { // + use<T> {
         let (tx, rx) = mpsc::unbounded_channel();
         tx.send(self.value.clone()).unwrap();
         self.senders.push(tx);
@@ -80,7 +80,7 @@ impl<K, V> ObservableHashMap<K, V>
 {
     #[expect(impl_trait_overcaptures,
     reason = "need to append `+ use<K, V>` to get correct semantics with Rust 2024 (but breaks IDE)")]
-    pub fn observe(&mut self, key: K) -> impl Stream<Item=Option<V>> { // + use<K, V> {
+    pub fn observe(&mut self, key: K) -> impl Stream<Item = Option<V>> { // + use<K, V> {
         match self.map.entry(key) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => entry.insert(Observable::default())
@@ -121,7 +121,7 @@ impl<K, V> ObservableHashMap<K, V>
     where K: Clone + Eq + Hash,
           V: Clone + PartialEq
 {
-    pub fn sync(&mut self, entries: impl IntoIterator<Item=(K, V)>) {
+    pub fn sync(&mut self, entries: impl IntoIterator<Item = (K, V)>) {
         let mut remaining_keys: HashSet<K> = self.map.keys().cloned().collect();
         for (key, value) in entries {
             remaining_keys.remove(&key);

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -697,9 +697,7 @@ impl TradeModel {
     }
 
     pub fn sign_custom_payout_psbt(&mut self) -> Result<()> {
-        self.custom_payout_tx
-            .builder
-            .sign_partial(&mut *self.trade_wallet()?)?;
+        self.custom_payout_tx.builder.sign_partial(&mut *self.trade_wallet()?)?;
         Ok(())
     }
 
@@ -766,16 +764,12 @@ pub enum ProtocolErrorKind {
     MissingTradeWallet,
     #[error("missing script key")]
     MissingScriptKey,
-    #[error(
-        "insufficient redirection funds (available {available_msat:?} msat, used {used_msat:?} msat)"
-    )]
+    #[error("insufficient redirection funds (available {available_msat:?} msat, used {used_msat:?} msat)")]
     InsufficientRedirectionFunds {
         available_msat: u64,
         used_msat: u64,
     },
-    #[error(
-        "excess redirection funds (available {available_msat:?} msat, used {used_msat:?} msat)"
-    )]
+    #[error("excess redirection funds (available {available_msat:?} msat, used {used_msat:?} msat)")]
     ExcessRedirectionFunds {
         available_msat: u64,
         used_msat: u64,

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -417,7 +417,7 @@ impl TradeModel {
     }
 
     pub fn set_redirection_receivers<I, E>(&mut self, receivers: I) -> Result<(), E>
-        where I: IntoIterator<Item=Result<Receiver<NetworkUnchecked>, E>>,
+        where I: IntoIterator<Item = Result<Receiver<NetworkUnchecked>, E>>,
               E: From<ProtocolErrorKind>
     {
         let network = self.trade_wallet()?.network();

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -266,7 +266,7 @@ impl musig_server::Musig for MusigImpl {
     }
 }
 
-fn mock_tx_confirmation_status_stream(trade_id: String, tx: Vec<u8>) -> impl Stream<Item=Result<TxConfirmationStatus>> {
+fn mock_tx_confirmation_status_stream(trade_id: String, tx: Vec<u8>) -> impl Stream<Item = Result<TxConfirmationStatus>> {
     let confirmation_event = TxConfirmationStatus {
         tx,
         current_block_height: 900_001,
@@ -358,7 +358,7 @@ impl<T> Stream for TracedResultStream<T> {
     }
 }
 
-pub trait TracedResultStreamExt<T: Serialize>: TryStream<Ok=T, Error=Status> + Sized + Send + 'static {
+pub trait TracedResultStreamExt<T: Serialize>: TryStream<Ok = T, Error = Status> + Sized + Send + 'static {
     fn box_traced(self) -> TracedResultStream<T> {
         TracedResultStream {
             inner: Box::pin(self.inspect_ok(move |event| {
@@ -371,7 +371,7 @@ pub trait TracedResultStreamExt<T: Serialize>: TryStream<Ok=T, Error=Status> + S
 }
 
 impl<S> TracedResultStreamExt<S::Ok> for S
-    where S: TryStream<Error=Status> + Sized + Send + 'static,
+    where S: TryStream<Error = Status> + Sized + Send + 'static,
           S::Ok: Serialize {}
 
 trait MusigRequest: Serialize {

--- a/rpc/src/test/java/bisq/BmpServiceIntegrationTest.java
+++ b/rpc/src/test/java/bisq/BmpServiceIntegrationTest.java
@@ -27,15 +27,15 @@ public class BmpServiceIntegrationTest {
     private TestEnvClient testenv;
 
     @BeforeAll
-    void setup() throws InterruptedException {
+    void setup() {
         // Initialize TestEnvClient from environment variables set by Maven
         try {
             testenv = TestEnvClient.fromEnv();
             System.out.println("Connected to TestEnv: " + testenv);
         } catch (RuntimeException e) {
             throw new RuntimeException(
-                "TestEnv RPC configuration is required to run integration tests.\n" + 
-                e.getMessage(), e);
+                    "TestEnv RPC configuration is required to run integration tests.\n" +
+                            e.getMessage(), e);
         }
 
         // Set up gRPC channels to both musigd servers (Alice on 50052, Bob on 50051)

--- a/rpc/src/test/java/bisq/TestEnvClient.java
+++ b/rpc/src/test/java/bisq/TestEnvClient.java
@@ -14,11 +14,13 @@ import java.util.regex.Pattern;
 
 /**
  * Bitcoin RPC client for TestEnv integration tests
- * <p>
- * Environment variables:
- * - TESTENV_RPC_URL
- * - TESTENV_RPC_USER
- * - TESTENV_RPC_PASS
+ *
+ * <p>Environment variables:
+ * <ul>
+ *   <li>{@code TESTENV_RPC_URL}
+ *   <li>{@code TESTENV_RPC_USER}
+ *   <li>{@code TESTENV_RPC_PASS}
+ * </ul>
  */
 public class TestEnvClient {
     private final HttpClient httpClient;

--- a/rpc/src/test/java/bisq/TestEnvClient.java
+++ b/rpc/src/test/java/bisq/TestEnvClient.java
@@ -1,4 +1,5 @@
 package bisq;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -13,14 +14,13 @@ import java.util.regex.Pattern;
 
 /**
  * Bitcoin RPC client for TestEnv integration tests
- *
+ * <p>
  * Environment variables:
  * - TESTENV_RPC_URL
  * - TESTENV_RPC_USER
  * - TESTENV_RPC_PASS
  */
 public class TestEnvClient {
-
     private final HttpClient httpClient;
     private final String rpcUrl;
     private final String rpcUser;
@@ -29,7 +29,7 @@ public class TestEnvClient {
     public static TestEnvClient fromEnv() {
         // Load from properties file if available
         Properties props = loadTestEnvProperties();
-        
+
         // Try system properties first (set by Maven via systemPropertyVariables)
         // Then fall back to loaded properties, then environment variables
         String rpcUrl = System.getProperty("bitcoinRpcUrl");
@@ -69,8 +69,8 @@ public class TestEnvClient {
         }
 
         if (rpcUrl == null) {
-            throw new RuntimeException(
-                    "\n========== FAILED TO INITIALIZE RPC CLIENT ==========\n" +
+            throw new RuntimeException("\n" +
+                    "========== FAILED TO INITIALIZE RPC CLIENT ==========\n" +
                     "TESTENV_RPC_URL not found. Please provide RPC configuration via one of:\n\n" +
                     "1. Maven command-line properties:\n" +
                     "   mvn -DbitcoinRpcUrl=http://localhost:18332 " +
@@ -91,8 +91,8 @@ public class TestEnvClient {
         }
 
         if (rpcPass == null) {
-            throw new RuntimeException(
-                    "\n========== FAILED TO INITIALIZE RPC CLIENT ==========\n" +
+            throw new RuntimeException("\n" +
+                    "========== FAILED TO INITIALIZE RPC CLIENT ==========\n" +
                     "TESTENV_RPC_PASS not found. Please provide RPC password via one of:\n\n" +
                     "1. Maven command-line property:\n" +
                     "   mvn -DbitcoinRpcPass=<password> -f rpc/pom.xml clean verify\n\n" +
@@ -128,7 +128,6 @@ public class TestEnvClient {
     }
 
     public TestEnvClient(String rpcUrl, String rpcUser, String rpcPass) {
-
         this.rpcUrl = rpcUrl;
         this.rpcUser = rpcUser;
         this.rpcPass = rpcPass;
@@ -139,17 +138,15 @@ public class TestEnvClient {
      * Generic RPC call
      */
     private String rpcCall(String method, String paramsJson) {
-
         try {
-
             String body = """
-            {
-              "jsonrpc":"1.0",
-              "id":"java",
-              "method":"%s",
-              "params":%s
-            }
-            """.formatted(method, paramsJson);
+                    {
+                      "jsonrpc":"1.0",
+                      "id":"java",
+                      "method":"%s",
+                      "params":%s
+                    }
+                    """.formatted(method, paramsJson);
 
             String auth = Base64.getEncoder()
                     .encodeToString((rpcUser + ":" + rpcPass).getBytes());
@@ -161,14 +158,12 @@ public class TestEnvClient {
                     .POST(HttpRequest.BodyPublishers.ofString(body))
                     .build();
 
-            HttpResponse<String> response =
-                    httpClient.send(
-                            request,
-                            HttpResponse.BodyHandlers.ofString()
-                    );
+            HttpResponse<String> response = httpClient.send(
+                    request,
+                    HttpResponse.BodyHandlers.ofString()
+            );
 
             return response.body();
-
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException("RPC call failed", e);
         }
@@ -177,28 +172,16 @@ public class TestEnvClient {
     /**
      * Mine blocks on regtest
      */
-    public int mineBlocks(int count) {
-
+    public void mineBlocks(int count) {
         String address = getNewAddress();
-
-        rpcCall(
-                "generatetoaddress",
-                "[" + count + ",\"" + address + "\"]"
-        );
-
-        return count;
+        rpcCall("generatetoaddress", "[" + count + ",\"" + address + "\"]");
     }
 
     /**
      * Fund an address
      */
     public String fundAddress(String address, double amount) {
-
-        String result = rpcCall(
-                "sendtoaddress",
-                "[\"" + address + "\"," + amount + "]"
-        );
-
+        String result = rpcCall("sendtoaddress", "[\"" + address + "\"," + amount + "]");
         return extractResult(result);
     }
 
@@ -206,12 +189,7 @@ public class TestEnvClient {
      * Get raw transaction hex
      */
     public String getRawTransaction(String txid) {
-
-        String result = rpcCall(
-                "getrawtransaction",
-                "[\"" + txid + "\"]"
-        );
-
+        String result = rpcCall("getrawtransaction", "[\"" + txid + "\"]");
         return extractResult(result);
     }
 
@@ -219,10 +197,7 @@ public class TestEnvClient {
      * Get current block height
      */
     public int getBlockCount() {
-        String result = rpcCall(
-                "getblockcount",
-                "[]"
-        );
+        String result = rpcCall("getblockcount", "[]");
         return Integer.parseInt(extractResult(result));
     }
 
@@ -230,10 +205,7 @@ public class TestEnvClient {
      * Get wallet balance
      */
     public double getBalance() {
-        String result = rpcCall(
-                "getbalance",
-                "[]"
-        );
+        String result = rpcCall("getbalance", "[]");
         return Double.parseDouble(extractResult(result));
     }
 
@@ -241,47 +213,35 @@ public class TestEnvClient {
      * Generate a new address
      */
     public String getNewAddress() {
-
-        String result = rpcCall(
-                "getnewaddress",
-                "[]"
-        );
-
-        String address = extractResult(result);
-        return address;
+        String result = rpcCall("getnewaddress", "[]");
+        return extractResult(result);
     }
 
     /**
      * Wait for transaction
      */
     public boolean waitForTransaction(String txid) {
-
         final long TIMEOUT_MS = 30_000;
         final long CHECK_INTERVAL_MS = 500;
 
         long start = System.currentTimeMillis();
-
         while (System.currentTimeMillis() - start < TIMEOUT_MS) {
-
             try {
-
                 String tx = getRawTransaction(txid);
-
                 if (tx != null && !tx.isBlank()) {
                     return true;
                 }
-
-            } catch (Exception ignored) {
+            } catch (RuntimeException ignored) {
             }
 
             try {
+                //noinspection BusyWait
                 Thread.sleep(CHECK_INTERVAL_MS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return false;
             }
         }
-
         return false;
     }
 
@@ -289,10 +249,7 @@ public class TestEnvClient {
      * Extract "result" field from JSON
      */
     private String extractResult(String json) {
-
-        Pattern pattern =
-                Pattern.compile("\"result\"\\s*:\\s*(\"([^\"]*)\"|[0-9\\.]+)");
-
+        Pattern pattern = Pattern.compile("\"result\"\\s*:\\s*(\"([^\"]*)\"|[0-9.]+)");
         Matcher matcher = pattern.matcher(json);
 
         if (matcher.find()) {
@@ -307,10 +264,6 @@ public class TestEnvClient {
 
     @Override
     public String toString() {
-
-        return "TestEnvClient{" +
-                "rpcUrl='" + rpcUrl + '\'' +
-                ", rpcUser='" + rpcUser + '\'' +
-                '}';
+        return "TestEnvClient{rpcUrl='" + rpcUrl + "', rpcUser='" + rpcUser + "'}";
     }
 }

--- a/rpc/src/wallet.rs
+++ b/rpc/src/wallet.rs
@@ -115,12 +115,12 @@ impl WalletServiceImpl {
     }
 }
 
-fn unconfirmed_txs(wallet: &Wallet) -> impl Iterator<Item=Arc<Transaction>> + '_ {
+fn unconfirmed_txs(wallet: &Wallet) -> impl Iterator<Item = Arc<Transaction>> + '_ {
     tx_confidence_entries(wallet)
         .filter_map(|(_, conf)| (conf.num_confirmations == 0).then_some(conf.wallet_tx.tx))
 }
 
-fn tx_confidence_entries(wallet: &Wallet) -> impl Iterator<Item=(Txid, TxConfidence)> + '_ {
+fn tx_confidence_entries(wallet: &Wallet) -> impl Iterator<Item = (Txid, TxConfidence)> + '_ {
     trace!( "Syncing confirmations.");
 
     let next_height = wallet.latest_checkpoint().height() + 1;

--- a/rpc/tests/cli.rs
+++ b/rpc/tests/cli.rs
@@ -218,14 +218,14 @@ fn mock_confidence_stream() -> BoxStream<'static, Option<TxConfidence>> {
     stream::iter([event1, event2, event3]).chain(stream::pending()).boxed()
 }
 
-fn assert_cli<'a>(args: impl IntoIterator<Item=&'a str>) -> Assert {
+fn assert_cli<'a>(args: impl IntoIterator<Item = &'a str>) -> Assert {
     cargo_bin_cmd!("musig-cli")
         .args(args)
         .timeout(CLI_TIMEOUT)
         .assert()
 }
 
-fn assert_cli_with_port<'a>(port: u16, args: impl IntoIterator<Item=&'a str>) -> Assert {
+fn assert_cli_with_port<'a>(port: u16, args: impl IntoIterator<Item = &'a str>) -> Assert {
     let port = port.to_string();
     #[expect(clippy::map_identity, reason = "change-of-lifetime false positive; see \
         https://github.com/rust-lang/rust-clippy/issues/9280")]

--- a/testenv/Cargo.toml
+++ b/testenv/Cargo.toml
@@ -26,3 +26,6 @@ electrsd = { version = "0.36.1", features = [
 hmac = "0.12.1"
 sha2 = "0.10.9"
 typed-arena = "2"
+
+[lints]
+workspace = true

--- a/testenv/Cargo.toml
+++ b/testenv/Cargo.toml
@@ -11,21 +11,18 @@ bdk_electrum = { workspace = true }
 bdk_wallet = { workspace = true, features = ["test-utils"] }
 bmp_tracing = { workspace = true }
 chain = { workspace = true }
+clap = { workspace = true }
 hex = { workspace = true }
 rand = { workspace = true }
 secp = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["net", "signal", "rt"] }
-typed-arena = "2"
 
-clap = { version = "4.6.0", features = ["derive"] }
-ctrlc = "3.4.0"
+ctrlc = "3.5.2"
 electrsd = { version = "0.36.1", features = [
 "esplora_a33e97e1",
 "corepc-node_29_0",
 ] }
 hmac = "0.12.1"
 sha2 = "0.10.9"
-
-[dev-dependencies]
-serde_json = "1"
+typed-arena = "2"

--- a/testenv/src/bin/testenv-server.rs
+++ b/testenv/src/bin/testenv-server.rs
@@ -1,6 +1,6 @@
 //! Usage:
 //!   cargo run --bin testenv-server -- --data-dir /path/to/persistent/dir
-//!   cargo run --bin testenv-server  # Uses TempDir (auto-deleted on exit)
+//!   cargo run --bin testenv-server  # Uses `TempDir` (auto-deleted on exit)
 
 use std::path::PathBuf;
 
@@ -23,23 +23,23 @@ fn main() -> Result<()> {
     let args = Args::parse();
 
     // Create TestEnv with optional data directory
-    let env = TestEnvBuilder::new(Some("bitcoin".to_string()))
+    let env = TestEnvBuilder::new(Some("bitcoin".to_owned()))
         .with_data_dir(args.data_dir.clone())
         .build()?;
 
     // Output connection information in a parseable format
     let rpc_port = env.bitcoin_rpc_port();
-    let rpc_url = format!("http://127.0.0.1:{}", rpc_port);
+    let rpc_url = format!("http://127.0.0.1:{rpc_port}");
     let electrum_url = env.electrum_url();
     let workdir = env.workdir();
 
     // Output as key=value pairs for easy parsing
     println!("TESTENV_READY=true");
-    println!("TESTENV_RPC_URL={}", rpc_url);
-    println!("TESTENV_RPC_PORT={}", rpc_port);
+    println!("TESTENV_RPC_URL={rpc_url}");
+    println!("TESTENV_RPC_PORT={rpc_port}");
     println!("TESTENV_RPC_USER=bitcoin");
     println!("TESTENV_RPC_PASS={}", env.bitcoin_rpc_password());
-    println!("TESTENV_ELECTRUM_URL={}", electrum_url);
+    println!("TESTENV_ELECTRUM_URL={electrum_url}");
     println!("TESTENV_WORKDIR={}", workdir.display());
     if let Some(data_dir) = &args.data_dir {
         println!("TESTENV_PERSISTENT=true");
@@ -49,8 +49,8 @@ fn main() -> Result<()> {
     }
 
     eprintln!("TestEnv server started successfully");
-    eprintln!("Bitcoin RPC: {} (user: bitcoin)", rpc_url);
-    eprintln!("Electrum: {}", electrum_url);
+    eprintln!("Bitcoin RPC: {rpc_url} (user: bitcoin)");
+    eprintln!("Electrum: {electrum_url}");
     eprintln!("Working directory: {}", workdir.display());
     if let Some(data_dir) = &args.data_dir {
         eprintln!("Persistent data directory: {}", data_dir.display());

--- a/testenv/src/lib.rs
+++ b/testenv/src/lib.rs
@@ -16,6 +16,7 @@ use bdk_wallet::bitcoin::key::Secp256k1;
 use bdk_wallet::bitcoin::secp256k1::All;
 use bdk_wallet::bitcoin::{Address, Amount, BlockHash, Network, Transaction, Txid};
 use bdk_wallet::chain::spk_client::{FullScanRequest, FullScanResponse};
+use bdk_wallet::serde_json;
 use bmp_tracing::tracing;
 use chain::{ChainApi, ChainScanner};
 use electrsd::corepc_node::Node;
@@ -703,8 +704,8 @@ impl ChainScanner for Testchain {
 fn broadcast_via(client: &BdkElectrumClient<Client>, tx: &Transaction) -> Result<Txid> {
     match client.transaction_broadcast(tx) {
         Ok(txid) => Ok(txid),
-        Err(Error::Protocol(e)) if e.as_str().is_some_and(
-            |s| s.starts_with("sendrawtransaction RPC error: {\"code\":-27,")) => {
+        Err(Error::Protocol(serde_json::Value::String(e))) if e.starts_with(
+            "sendrawtransaction RPC error: {\"code\":-27,") => {
             Ok(tx.compute_txid())
         }
         Err(e) => Err(e.into()),
@@ -735,7 +736,6 @@ impl Drop for TestEnv {
 #[cfg(test)]
 mod tests {
     use bdk_bitcoind_rpc::bitcoincore_rpc::RpcApi as _;
-    use bdk_wallet::serde_json;
     use bmp_tracing::tracing;
 
     use super::*;

--- a/testenv/src/lib.rs
+++ b/testenv/src/lib.rs
@@ -731,6 +731,7 @@ impl Drop for TestEnv {
 #[cfg(test)]
 mod tests {
     use bdk_bitcoind_rpc::bitcoincore_rpc::RpcApi as _;
+    use bdk_wallet::serde_json;
     use bmp_tracing::tracing;
 
     use super::*;

--- a/testenv/src/lib.rs
+++ b/testenv/src/lib.rs
@@ -99,7 +99,7 @@ impl Default for Config<'_> {
 
 const NETWORK: Network = Network::Regtest;
 
-/// Builder for TestEnv configuration with optional data directory support
+/// Builder for `TestEnv` configuration with optional data directory support
 #[derive(Debug, Clone, Default)]
 pub struct TestEnvBuilder {
     config: Config<'static>,
@@ -111,9 +111,9 @@ impl TestEnvBuilder {
         Self {
             config: Config {
                 password,
-                ..Default::default()
+                ..Config::default()
             },
-            data_dir: Default::default(),
+            data_dir: Option::default(),
         }
     }
 
@@ -121,12 +121,13 @@ impl TestEnvBuilder {
     ///
     /// If not set, a temporary directory will be used (auto-deleted on exit).
     /// If set, the directory will be created if it doesn't exist and persist across runs.
+    #[must_use]
     pub fn with_data_dir(mut self, path: Option<std::path::PathBuf>) -> Self {
         self.data_dir = path;
         self
     }
 
-    /// Build the TestEnv with the configured settings
+    /// Build the `TestEnv` with the configured settings
     pub fn build(mut self) -> Result<TestEnv> {
         if let Some(data_dir) = &self.data_dir {
             // Create the data directory if it doesn't exist
@@ -262,13 +263,13 @@ impl TestEnv {
 
     /// ZMQ socket for raw block notifications (set when created via
     /// [`enable_zmq`](Self::enable_zmq)).
-    pub fn zmq_pub_raw_block_socket(&self) -> Option<SocketAddrV4> {
+    pub const fn zmq_pub_raw_block_socket(&self) -> Option<SocketAddrV4> {
         self.bitcoind.params.zmq_pub_raw_block_socket
     }
 
     /// create environment with automatic downloads
     pub fn new_with_conf(config: Config) -> Result<Self> {
-        let _guard = if config.runmultithreaded {
+        let guard = if config.runmultithreaded {
             None
         } else {
             // can recover because unit type won't corrupt
@@ -333,7 +334,7 @@ impl TestEnv {
             explorer_port: None,
             bitcoin_rpc_pwd,
             mempool: Vec::new(),
-            _guard,
+            _guard: guard,
             dirs: Arena::new(),
         };
         tracing::info!("Bitcoin regtest environment ready!");
@@ -427,7 +428,7 @@ impl TestEnv {
         }
     }
 
-    pub fn bitcoin_rpc_port(&self) -> u16 {
+    pub const fn bitcoin_rpc_port(&self) -> u16 {
         self.bitcoind.params.rpc_socket.port()
     }
 
@@ -442,7 +443,7 @@ impl TestEnv {
         &self.bdk_electrum_client.inner
     }
 
-    pub fn bitcoind_client(&self) -> &corepc_node::Client {
+    pub const fn bitcoind_client(&self) -> &corepc_node::Client {
         &self.bitcoind.client
     }
 
@@ -457,7 +458,7 @@ impl TestEnv {
         self.electrsd.electrum_url.replace("0.0.0.0", "127.0.0.1")
     }
 
-    pub fn bdk_electrum_client(&self) -> &BdkElectrumClient<Client> {
+    pub const fn bdk_electrum_client(&self) -> &BdkElectrumClient<Client> {
         &self.bdk_electrum_client
     }
 
@@ -478,7 +479,7 @@ impl TestEnv {
 
         self.wait_for_block()?;
 
-        for txid in self.mempool.iter() {
+        for txid in &self.mempool {
             let _ = self.wait_for_tx(*txid);
         }
         self.mempool.clear();
@@ -620,7 +621,7 @@ impl TestEnv {
     }
 
     /// Get the running bitcoind socket address
-    pub fn p2p_socket_addr(&self) -> Option<SocketAddrV4> {
+    pub const fn p2p_socket_addr(&self) -> Option<SocketAddrV4> {
         self.bitcoind.params.p2p_socket
     }
 
@@ -774,6 +775,8 @@ mod tests {
 
     #[test]
     fn test_address_operations() -> Result<()> {
+        use electrsd::corepc_node::vtype::TransactionCategory;
+
         let mut env = TestEnv::new()?;
 
         // Create new address
@@ -811,7 +814,6 @@ mod tests {
         let tx = env.bitcoind.client.get_transaction(txid)?;
 
         // Extract the received amount from transaction details
-        use electrsd::corepc_node::vtype::TransactionCategory;
         let receive_amount = tx
             .details
             .iter()
@@ -827,15 +829,15 @@ mod tests {
 
     #[test]
     fn test_persistent_data_dir() -> Result<()> {
+        // Number of blocks beyond the initial height we mine in the first run.
+        const MINED: usize = 5;
+
         // A persistent `data_dir` should make bitcoind's chain state survive a full
         // shut-down/restart cycle, in contrast to the default throwaway temp dirs.
         let data_root = TempDir::new()?;
         let data_dir = data_root.path().to_path_buf();
         let bitcoind_dir = data_dir.join("bitcoind");
         let electrsd_dir = data_dir.join("electrsd");
-
-        // Number of blocks beyond the initial height we mine in the first run.
-        const MINED: usize = 5;
 
         let persisted_height = {
             let mut env = TestEnvBuilder::new(None)

--- a/testenv/src/lib.rs
+++ b/testenv/src/lib.rs
@@ -10,6 +10,7 @@ use bdk_bitcoind_rpc::bitcoincore_rpc;
 use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, RpcApi as _};
 use bdk_electrum::BdkElectrumClient;
 use bdk_electrum::bdk_core::bitcoin::{KnownHrp, XOnlyPublicKey};
+use bdk_electrum::electrum_client::Error;
 use bdk_wallet::bitcoin::address::NetworkChecked;
 use bdk_wallet::bitcoin::key::Secp256k1;
 use bdk_wallet::bitcoin::secp256k1::All;
@@ -697,11 +698,13 @@ impl ChainScanner for Testchain {
 }
 
 /// Shared `ChainApi::transaction_broadcast` body — swallows the idempotent
-/// "Transaction already in block chain" Electrum error and returns the computed txid.
+/// "Transaction outputs already in utxo set" Electrum error (forwarded bitcoin RPC error -27) and
+/// returns the computed txid.
 fn broadcast_via(client: &BdkElectrumClient<Client>, tx: &Transaction) -> Result<Txid> {
     match client.transaction_broadcast(tx) {
         Ok(txid) => Ok(txid),
-        Err(e) if e.to_string().contains("Transaction already in block chain") => {
+        Err(Error::Protocol(e)) if e.as_str().is_some_and(
+            |s| s.starts_with("sendrawtransaction RPC error: {\"code\":-27,")) => {
             Ok(tx.compute_txid())
         }
         Err(e) => Err(e.into()),

--- a/testenv/src/lib.rs
+++ b/testenv/src/lib.rs
@@ -92,7 +92,7 @@ impl Default for Config<'_> {
             timeout: Duration::from_secs(5),
             delay: Duration::from_millis(200),
             password: None,
-            runmultithreaded: "true" == std::env::var("TEST_MULTITHREADED").unwrap_or_else(|_| "false".to_string()).trim().to_lowercase()
+            runmultithreaded: "true" == std::env::var("TEST_MULTITHREADED").unwrap_or_default().trim().to_lowercase(),
         }
     }
 }
@@ -152,10 +152,8 @@ impl TestEnvBuilder {
     }
 }
 
-
 // Type alias for Hmac-Sha256
 type HmacSha256 = Hmac<Sha256>;
-
 
 /// Generates a Bitcoin Core rpcauth string.
 ///
@@ -222,6 +220,7 @@ pub fn validate_rpcauth(rpcauth_line: &str, username: &str, password: &str) -> b
     // but you can use `subtle` crate if you want constant-time equality.
     hmac_hex_actual.eq_ignore_ascii_case(hmac_hex_expected)
 }
+
 static TESTENV_LOCK: Mutex<()> = Mutex::new(());
 
 impl TestEnv {
@@ -650,7 +649,7 @@ impl ChainScanner for TestEnv {
         stop_gap: usize,
         batch_size: usize,
         fetch_prev_txouts: bool,
-    ) -> anyhow::Result<FullScanResponse<K>> {
+    ) -> Result<FullScanResponse<K>> {
         self.bdk_electrum_client
             .full_scan(request, stop_gap, batch_size, fetch_prev_txouts)
             .map_err(Into::into)
@@ -673,7 +672,7 @@ impl Testchain {
 }
 
 impl ChainApi for Testchain {
-    fn transaction_broadcast(&self, tx: &Transaction) -> anyhow::Result<Txid> {
+    fn transaction_broadcast(&self, tx: &Transaction) -> Result<Txid> {
         broadcast_via(&self.client, tx)
     }
 }
@@ -689,7 +688,7 @@ impl ChainScanner for Testchain {
         stop_gap: usize,
         batch_size: usize,
         fetch_prev_txouts: bool,
-    ) -> anyhow::Result<FullScanResponse<K>> {
+    ) -> Result<FullScanResponse<K>> {
         self.client
             .full_scan(request, stop_gap, batch_size, fetch_prev_txouts)
             .map_err(Into::into)
@@ -698,7 +697,7 @@ impl ChainScanner for Testchain {
 
 /// Shared `ChainApi::transaction_broadcast` body — swallows the idempotent
 /// "Transaction already in block chain" Electrum error and returns the computed txid.
-fn broadcast_via(client: &BdkElectrumClient<Client>, tx: &Transaction) -> anyhow::Result<Txid> {
+fn broadcast_via(client: &BdkElectrumClient<Client>, tx: &Transaction) -> Result<Txid> {
     match client.transaction_broadcast(tx) {
         Ok(txid) => Ok(txid),
         Err(e) if e.to_string().contains("Transaction already in block chain") => {

--- a/testenv/src/lib.rs
+++ b/testenv/src/lib.rs
@@ -887,6 +887,7 @@ mod tests {
             reloaded_height, persisted_height,
             "block height should persist across restarts when a data dir is set"
         );
+        drop(env2);
 
         // Sanity check: a default (non-persistent) env is independent and starts fresh.
         let ephemeral = TestEnv::new()?;

--- a/testenv/tests/persistent_server.rs
+++ b/testenv/tests/persistent_server.rs
@@ -109,16 +109,15 @@ impl ServerHandle {
         let deadline = Instant::now() + Duration::from_secs(30);
         loop {
             match self.child.try_wait() {
-                Ok(Some(_)) => break,
                 Ok(None) if Instant::now() < deadline => {
-                    std::thread::sleep(Duration::from_millis(100))
+                    std::thread::sleep(Duration::from_millis(100));
                 }
                 Ok(None) => {
                     let _ = self.child.kill();
                     let _ = self.child.wait();
                     break;
                 }
-                Err(_) => break,
+                Ok(Some(_)) | Err(_) => break,
             }
         }
     }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -10,17 +10,16 @@ base64 = { workspace = true }
 bdk_electrum = { workspace = true }
 bdk_kyoto = { workspace = true }
 bdk_wallet = { workspace = true }
+chain = { workspace = true }
 hex = { workspace = true }
 rand = { workspace = true }
 rusqlite = { workspace = true }
 secp = { workspace = true }
 tracing = { workspace = true }
 zeroize = { workspace = true }
-thiserror =  { workspace = true }
-
-chain = { workspace = true }
+thiserror = { workspace = true }
 # TODO move this to dev-dependencies:
-testenv = { path = "../testenv" }
+testenv = { workspace = true }
 
 [dev-dependencies]
 bdk_wallet = { workspace = true, features = ["test-utils"] }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -25,3 +25,6 @@ testenv = { workspace = true }
 bdk_wallet = { workspace = true, features = ["test-utils"] }
 bmp_tracing = { workspace = true }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/wallet/src/bmp_wallet.rs
+++ b/wallet/src/bmp_wallet.rs
@@ -117,12 +117,11 @@ impl BMPWalletPersister for Connection {
         let trx = db.transaction()?;
         {
             let mut stmt = trx.prepare(&format!(
-                "INSERT INTO {}(seed) VALUES(:seed)",
-                seeds_table_name
+                "INSERT INTO {seeds_table_name}(seed) VALUES(:seed)"
             ))?;
 
             stmt.execute(named_params! {
-                    ":seed": seed_phrase
+                ":seed": seed_phrase
             })?;
         }
 
@@ -133,7 +132,7 @@ impl BMPWalletPersister for Connection {
     fn load_imported_keys(db: &mut Self::DB, keys_table_name: &str) -> anyhow::Result<Vec<Scalar>> {
         let mut imported_keys: Vec<Scalar> = vec![];
 
-        let mut statement = db.prepare(&format!("SELECT key FROM {}", keys_table_name))?;
+        let mut statement = db.prepare(&format!("SELECT key FROM {keys_table_name}"))?;
 
         let row_iter = statement.query_map([], |row| Ok((row.get::<_, String>("key")?,)))?;
 
@@ -154,8 +153,7 @@ impl BMPWalletPersister for Connection {
         let db_trx = db.transaction()?;
         {
             let mut statement = db_trx.prepare_cached(&format!(
-                "INSERT OR IGNORE INTO {} (key) VALUES (:key)",
-                keys_table_name
+                "INSERT OR IGNORE INTO {keys_table_name} (key) VALUES (:key)"
             ))?;
 
             for key in keys {
@@ -171,7 +169,7 @@ impl BMPWalletPersister for Connection {
 
     fn get_seed_phrase(db: &Self::DB, seeds_table_name: &str) -> anyhow::Result<String> {
         let mnemonic = db.query_row(
-            &format!("SELECT seed FROM {}", seeds_table_name),
+            &format!("SELECT seed FROM {seeds_table_name}"),
             (),
             |row| row.get::<_, String>("seed"),
         )?;
@@ -182,7 +180,6 @@ impl BMPWalletPersister for Connection {
 
 const STOP_GAP: usize = 50;
 
-#[allow(unused)]
 pub struct BMPWallet<P: BMPWalletPersister> {
     wallet: PersistedWallet<P>,
     imported_keys: Vec<Scalar>,
@@ -210,8 +207,7 @@ impl BMPWallet<Connection> {
             let next_index = if let Some(last_addr) = &self.last_unused_address {
                 // Search for the last address in the current unused list
                 unused.iter().position(|info| info.address.to_string() == *last_addr)
-                    .map(|idx| (idx + 1) % unused.len())
-                    .unwrap_or(0)
+                    .map_or(0, |idx| (idx + 1) % unused.len())
             } else {
                 // No previous address, start with the first one
                 0
@@ -243,11 +239,14 @@ impl BMPWallet<Connection> {
     /// Helper function to run a CBF node
     /// This will:
     /// - Create a new Light client
-    /// - spawn two threads one for trace logs and another for the server node
+    /// - spawn two tasks, one for trace logs and another for the server node
     /// - Return the requester and the subscriber from which the updates can be pulled
     ///
     /// Note: The caller is responsible for shutting down the requester at will.
-    pub async fn run_node(
+    ///
+    /// # Panics
+    /// Will panic if called outside the context of a Tokio runtime
+    pub fn run_node(
         wallet: &Wallet,
         scan_type: ScanType,
         peers: Vec<TrustedPeer>,
@@ -281,7 +280,7 @@ impl BMPWallet<Connection> {
                     .iter()
                     .map(|scalar| {
                         let pbk = scalar.base_point_mul().serialize_xonly();
-                        XOnlyPublicKey::from_slice(&pbk).expect("Should be valid xonlypub key")
+                        XOnlyPublicKey::from_slice(&pbk).expect("Should be valid xonly pubkey")
                     })
                     .find(|pubkey| {
                         let script = ScriptBuf::new_p2tr(secp, *pubkey, None);
@@ -401,7 +400,7 @@ pub trait WalletApi {
         peers: Vec<TrustedPeer>,
     ) -> impl Future<Output = anyhow::Result<()>> + Send;
 
-    fn drain_imported_balance(&mut self, feerate: FeeRate) -> anyhow::Result<Psbt>;
+    fn drain_imported_balance(&mut self, fee_rate: FeeRate) -> anyhow::Result<Psbt>;
 }
 
 impl WalletApi for BMPWallet<Connection> {
@@ -429,7 +428,7 @@ impl WalletApi for BMPWallet<Connection> {
         let mut db = Connection::new(db_path)?;
 
         // Derive encryption key
-        let salt_path = format!("{}.salt", db_path);
+        let salt_path = format!("{db_path}.salt");
         let mut salt = [0u8; 16];
         rand::rng().fill_bytes(&mut salt);
         fs::write(&salt_path, general_purpose::STANDARD.encode(salt))?;
@@ -491,7 +490,7 @@ impl WalletApi for BMPWallet<Connection> {
             for key in &self.imported_keys {
                 let xonly_pubkey = key.base_point_mul().serialize_xonly();
                 let xonly_pubkey = XOnlyPublicKey::from_slice(&xonly_pubkey)
-                    .expect("Should be valid xonlypub key");
+                    .expect("Should be valid xonly pubkey");
                 let script = ScriptBuf::new_p2tr(secp, xonly_pubkey, None);
 
                 if script == *input_script {
@@ -506,7 +505,7 @@ impl WalletApi for BMPWallet<Connection> {
 
             if let Some(signing_key) = is_mine(&txout.script_pubkey) {
                 let signer = PrivateKey::from_slice(&signing_key.serialize(), self.network())
-                    .map_err(|_e| SignerError::External("Invalid signing key".to_string()))?;
+                    .map_err(|_e| SignerError::External("Invalid signing key".to_owned()))?;
 
                 let sw = SignerWrapper::new(
                     signer,
@@ -517,7 +516,7 @@ impl WalletApi for BMPWallet<Connection> {
 
                 sw.sign_input(psbt, input_index, &sign_options, secp)?;
                 psbt.finalize_inp_mut(secp, input_index)
-                    .map_err(|_e| SignerError::External("Unable to finalized input".to_string()))?;
+                    .map_err(|_e| SignerError::External("Unable to finalized input".to_owned()))?;
             }
         }
 
@@ -526,21 +525,20 @@ impl WalletApi for BMPWallet<Connection> {
             tracing::info!("Loading the signers into the wallet");
             let recovery_phrase = self
                 .get_seed_phrase()
-                .map_err(|_| SignerError::External("Unable to load keys.".to_string()))?;
-            let mnemonic = Mnemonic::parse_normalized(&recovery_phrase).map_err(|_| {
-                SignerError::External("Unable to parse recovery phrase".to_string())
-            })?;
+                .map_err(|_| SignerError::External("Unable to load keys.".to_owned()))?;
+            let mnemonic = Mnemonic::parse_normalized(&recovery_phrase)
+                .map_err(|_| SignerError::External("Unable to parse recovery phrase".to_owned()))?;
 
             let xprv = Xpriv::new_master(self.network(), &mnemonic.to_entropy())
-                .map_err(|_| SignerError::External("Unable to load keys".to_string()))?;
+                .map_err(|_| SignerError::External("Unable to load keys".to_owned()))?;
 
             let (_, external_map, _) = Bip86(xprv, KeychainKind::External)
                 .build(self.network())
-                .map_err(|_| SignerError::External("BIP 86 derivation failed".to_string()))?;
+                .map_err(|_| SignerError::External("BIP 86 derivation failed".to_owned()))?;
 
             let (_, internal_map, _) = Bip86(xprv, KeychainKind::Internal)
                 .build(self.network())
-                .map_err(|_| SignerError::External("BIP 86 derivation failed".to_string()))?;
+                .map_err(|_| SignerError::External("BIP 86 derivation failed".to_owned()))?;
 
             self.wallet.set_keymap(KeychainKind::External, external_map);
             self.wallet.set_keymap(KeychainKind::Internal, internal_map);
@@ -560,7 +558,7 @@ impl WalletApi for BMPWallet<Connection> {
         scan_type: ScanType,
         peers: Vec<TrustedPeer>,
     ) -> anyhow::Result<()> {
-        let (requester, mut updates_sub) = Self::run_node(self, scan_type, peers).await?;
+        let (requester, mut updates_sub) = Self::run_node(self, scan_type, peers)?;
         let updates = updates_sub.update().await?;
 
         self.apply_update(updates)?;
@@ -576,6 +574,13 @@ impl WalletApi for BMPWallet<Connection> {
         scan_type: ScanType,
         peers: Vec<TrustedPeer>,
     ) -> anyhow::Result<()> {
+        struct KeyEntry {
+            db: Connection,
+            wallet: PersistedWallet<Connection>,
+            update_subscriber: UpdateSubscriber,
+            requester: Requester,
+        }
+
         let pubkeys = self
             .imported_keys
             .iter()
@@ -584,13 +589,6 @@ impl WalletApi for BMPWallet<Connection> {
 
         // Build all wallets and light clients upfront, then run all nodes concurrently
         // so their peer connections overlap (gossip addresses from one benefit the others).
-        struct KeyEntry {
-            db: Connection,
-            wallet: PersistedWallet<Connection>,
-            update_subscriber: UpdateSubscriber,
-            requester: Requester,
-        }
-
         let mut entries: Vec<KeyEntry> = Vec::with_capacity(pubkeys.len());
         for key in &pubkeys {
             let path_str = self.db.path().expect("DB path should not be empty").replace(Self::DB_NAME, "");
@@ -601,14 +599,11 @@ impl WalletApi for BMPWallet<Connection> {
                 .check_network(self.wallet.network())
                 .extract_keys()
                 .load_wallet(&mut db)?;
-            let wallet = match imported_wallet_opt {
-                Some(w) => w,
-                None => {
-                    let descriptor = format!("tr({})", key.to_lower_hex_string());
-                    Wallet::create_single(descriptor)
-                        .network(self.wallet.network())
-                        .create_wallet(&mut db)?
-                }
+            let wallet = if let Some(w) = imported_wallet_opt { w } else {
+                let descriptor = format!("tr({})", key.to_lower_hex_string());
+                Wallet::create_single(descriptor)
+                    .network(self.wallet.network())
+                    .create_wallet(&mut db)?
             };
             let LightClient {
                 requester,
@@ -652,9 +647,9 @@ impl WalletApi for BMPWallet<Connection> {
 
         for key in self.imported_keys.clone() {
             let pbk = key.base_point_mul();
-            let pubk = pbk.serialize_xonly().to_lower_hex_string();
+            let pubkey = pbk.serialize_xonly().to_lower_hex_string();
             let path_str = self.db.path().expect("DB path should not be empty").replace(Self::DB_NAME, "");
-            let db_path = Path::new(&path_str).join(format!("bmp_{}.db3", pubk));
+            let db_path = Path::new(&path_str).join(format!("bmp_{pubkey}.db3"));
 
             let mut db = Connection::open(db_path)?;
             let imported_wallet_opt = Wallet::load()
@@ -662,15 +657,12 @@ impl WalletApi for BMPWallet<Connection> {
                 .extract_keys()
                 .load_wallet(&mut db)?;
 
-            let mut imported_wallet = match imported_wallet_opt {
-                Some(wallet) => wallet,
-                None => {
-                    let descriptor = format!("tr({})", pubk);
+            let mut imported_wallet = if let Some(wallet) = imported_wallet_opt { wallet } else {
+                let descriptor = format!("tr({pubkey})");
 
-                    Wallet::create_single(descriptor)
-                        .network(self.wallet.network())
-                        .create_wallet(&mut db)?
-                }
+                Wallet::create_single(descriptor)
+                    .network(self.wallet.network())
+                    .create_wallet(&mut db)?
             };
 
             data_source.sync(&mut imported_wallet)?;
@@ -695,7 +687,7 @@ impl WalletApi for BMPWallet<Connection> {
     fn load_wallet(path: &Path, network: Network, password: &str) -> anyhow::Result<Self> {
         let (salt, mut db) = {
             let p = path.join(Self::DB_NAME);
-            println!("Path set joining .. {p:?}");
+            println!("Path set joining .. {}", p.display());
             (
                 get_salt(p.to_str().expect("Path must not be empty"))?,
                 Connection::open(p)?,
@@ -800,7 +792,7 @@ impl DerefMut for BMPWallet<Connection> {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::str::FromStr as _;
 
     use bdk_kyoto::FeeRate;
     use bdk_wallet::bitcoin::hashes::Hash as _;
@@ -813,7 +805,7 @@ mod tests {
     use secp::Scalar;
     use tempfile::{TempDir, tempdir};
 
-    use crate::bmp_wallet::{BMPWallet, STOP_GAP, WalletApi};
+    use crate::bmp_wallet::{BMPWallet, STOP_GAP, WalletApi as _};
     use crate::test_utils::{MockedBDKElectrum, derive_public_key, load_imported_wallet};
 
     fn get_dir() -> TempDir {
@@ -1006,9 +998,9 @@ mod tests {
         let mut bmp_wallet = BMPWallet::new(dir.path(), "", Network::Regtest)?;
 
         let keys_to_import = [new_private_key(), new_private_key()];
-        keys_to_import
-            .iter()
-            .for_each(|k| bmp_wallet.import_private_key(*k));
+        for k in &keys_to_import {
+            bmp_wallet.import_private_key(*k);
+        }
 
         tracing::info!("Wallet balance before syncing {}", bmp_wallet.balance());
         assert_eq!(bmp_wallet.balance(), Amount::from_int_btc(0));
@@ -1033,7 +1025,7 @@ mod tests {
         assert_eq!(first_key_unspents.len(), 1);
         assert_eq!(second_key_unspents.len(), 1);
 
-        first_key_unspents.iter().for_each(|i| {
+        for i in &first_key_unspents {
             let psbt_input = psbt::Input {
                 witness_utxo: Some(i.txout.clone()),
                 tap_internal_key: Some(derive_public_key(&keys_to_import[0])),
@@ -1042,9 +1034,9 @@ mod tests {
             tx_builder
                 .add_foreign_utxo(i.outpoint, psbt_input, Weight::from_wu(66))
                 .unwrap();
-        });
+        }
 
-        second_key_unspents.iter().for_each(|i| {
+        for i in &second_key_unspents {
             let psbt_input = psbt::Input {
                 witness_utxo: Some(i.txout.clone()),
                 tap_internal_key: Some(derive_public_key(&keys_to_import[1])),
@@ -1053,7 +1045,7 @@ mod tests {
             tx_builder
                 .add_foreign_utxo(i.outpoint, psbt_input, Weight::from_wu(66))
                 .unwrap();
-        });
+        }
 
         let mut res_psbt = tx_builder.finish()?;
 

--- a/wallet/src/bmp_wallet.rs
+++ b/wallet/src/bmp_wallet.rs
@@ -193,11 +193,13 @@ pub struct BMPWallet<P: BMPWalletPersister> {
 }
 
 impl BMPWallet<Connection> {
-
-    pub fn list_unused_addresses_since_last_used(&self, key_chain: KeychainKind) -> impl Iterator<Item = AddressInfo> + '_  {
+    pub fn list_unused_addresses_since_last_used(
+        &self,
+        key_chain: KeychainKind,
+    ) -> impl Iterator<Item = AddressInfo> + '_ {
         let last_used = self.spk_index().last_used_index(key_chain);
         self.list_unused_addresses(key_chain)
-           .filter(move |info| last_used.is_none_or(|idx| info.index > idx))
+            .filter(move |info| last_used.is_none_or(|idx| info.index > idx))
     }
 
     pub fn next_address(&mut self, key_chain: KeychainKind) -> anyhow::Result<AddressInfo> {
@@ -216,10 +218,10 @@ impl BMPWallet<Connection> {
             };
 
             let selected = unused[next_index].clone();
-            
+
             // Update index to track the address just given out
             self.last_unused_address = Some(selected.address.to_string());
-            
+
             selected
         } else {
             let addr = self.reveal_next_address(key_chain);
@@ -1227,6 +1229,7 @@ mod tests {
 
         Ok(())
     }
+
     #[test]
     fn test_list_unused_addresses_since_last_used() -> anyhow::Result<()> {
         let dir = get_dir();

--- a/wallet/src/chain_data_source.rs
+++ b/wallet/src/chain_data_source.rs
@@ -1,5 +1,5 @@
 use bdk_wallet::PersistedWallet;
-use chain::ChainScanner;
+use chain::ChainScanner as _;
 
 use crate::bmp_wallet::BMPWalletPersister;
 

--- a/wallet/src/chain_data_source.rs
+++ b/wallet/src/chain_data_source.rs
@@ -27,8 +27,7 @@ impl ChainDataSource for testenv::Testchain {
         self.populate_tx_cache(tx_nodes);
         let request = persister.start_full_scan();
 
-        let updates = self
-            .full_scan(request, Self::STOP_GAP, Self::BATCH_SIZE, false)?;
+        let updates = self.full_scan(request, Self::STOP_GAP, Self::BATCH_SIZE, false)?;
 
         persister.apply_update(updates)?;
 

--- a/wallet/src/coin_selection.rs
+++ b/wallet/src/coin_selection.rs
@@ -32,24 +32,22 @@ impl CoinSelectionAlgorithm for AlwaysSpendImportedFirst {
             rand,
         );
 
-        match cs_result {
-            Ok(res) => Ok(res),
-            Err(_) => {
-                // Take the required and put them inside the optional and replace the required with
-                // the imported utxos This is done so that imported utxos always get
-                // spent first
-                optional_utxos.append(&mut required_utxos);
-                required_utxos.append(&mut imported_utxos);
+        if let Ok(res) = cs_result {
+            Ok(res)
+        } else {
+            // Take the required and put them inside the optional and replace the required with the
+            // imported utxos This is done so that imported utxos always get spent first
+            optional_utxos.append(&mut required_utxos);
+            required_utxos.append(&mut imported_utxos);
 
-                bnb.coin_select(
-                    required_utxos,
-                    optional_utxos,
-                    fee_rate,
-                    target_amount,
-                    drain_script,
-                    rand,
-                )
-            }
+            bnb.coin_select(
+                required_utxos,
+                optional_utxos,
+                fee_rate,
+                target_amount,
+                drain_script,
+                rand,
+            )
         }
     }
 }

--- a/wallet/src/protocol_wallet_api.rs
+++ b/wallet/src/protocol_wallet_api.rs
@@ -55,6 +55,7 @@ pub trait ProtocolWalletApi {
     // After importing a rescan should be triggered
     fn import_private_key(&mut self, pk: Scalar);
 }
+
 pub struct MemWallet {
     wallet: Wallet,
     client: BdkElectrumClient<Client>,

--- a/wallet/src/protocol_wallet_api.rs
+++ b/wallet/src/protocol_wallet_api.rs
@@ -1,4 +1,4 @@
-use std::io::Write;
+use std::io::Write as _;
 use std::mem;
 use std::sync::LazyLock;
 
@@ -9,12 +9,12 @@ use bdk_electrum::electrum_client::Client;
 use bdk_wallet::bitcoin::{Address, Amount, FeeRate, Network, OutPoint, Psbt, ScriptBuf};
 use bdk_wallet::coin_selection::CoinSelectionAlgorithm;
 use bdk_wallet::descriptor::{Descriptor, ExtendedDescriptor};
-use bdk_wallet::miniscript::ToPublicKey;
+use bdk_wallet::miniscript::ToPublicKey as _;
 use bdk_wallet::miniscript::descriptor::ConversionError;
 use bdk_wallet::miniscript::psbt::PsbtExt as _;
-use bdk_wallet::template::{Bip86, DescriptorTemplate};
+use bdk_wallet::template::{Bip86, DescriptorTemplate as _};
 use bdk_wallet::{AddressInfo, KeychainKind, SignOptions, TxBuilder, TxOrdering, Wallet};
-use rand::RngCore;
+use rand::RngCore as _;
 use secp::Scalar;
 use thiserror::Error;
 
@@ -269,7 +269,7 @@ impl ProtocolWalletApi for Wallet {
         }
         // TODO unify signing
         sign_selected_inputs_with(self, psbt, is_selected, |w, p, opts| {
-            Wallet::sign(w, p, opts)?;
+            Self::sign(w, p, opts)?;
             Ok(())
         })
     }

--- a/wallet/src/test_utils.rs
+++ b/wallet/src/test_utils.rs
@@ -18,6 +18,7 @@ use secp::Scalar;
 
 use crate::bmp_wallet::BMPWalletPersister;
 use crate::chain_data_source::ChainDataSource;
+
 pub struct MockedBDKElectrum;
 
 impl ChainDataSource for MockedBDKElectrum {
@@ -76,18 +77,18 @@ pub fn verify_signature(
 
     // add tweak. this was taken from `signer::sign_psbt_schnorr`
     let keypair = keypair.tap_tweak(&secp, None).to_keypair();
-    let xonlykey = XOnlyPublicKey::from_keypair(&keypair).0; // ignoring the parity
+    let xonly_pubkey = XOnlyPublicKey::from_keypair(&keypair).0; // ignoring the parity
 
     // Must verify if we used the correct key to sign
-    let verify_res = secp.verify_schnorr(&signature, &message, &xonlykey);
+    let verify_res = secp.verify_schnorr(&signature, &message, &xonly_pubkey);
     assert!(verify_res.is_ok(), "The wrong internal key was used");
     Ok(())
 }
 
 pub fn load_imported_wallet(p: &Path, key: &Scalar) -> anyhow::Result<PersistedWallet<Connection>> {
     let pbk = key.base_point_mul();
-    let pubk = pbk.serialize_xonly().to_lower_hex_string();
-    let db_path = format!("bmp_{}.db3", pubk);
+    let pubkey = pbk.serialize_xonly().to_lower_hex_string();
+    let db_path = format!("bmp_{pubkey}.db3");
     let db_path = p.join(db_path);
 
     let mut db = Connection::open(db_path)?;
@@ -101,7 +102,7 @@ pub fn load_imported_wallet(p: &Path, key: &Scalar) -> anyhow::Result<PersistedW
 
 pub fn derive_public_key(key: &Scalar) -> XOnlyPublicKey {
     let xonly_pubkey = key.base_point_mul().serialize_xonly();
-    XOnlyPublicKey::from_slice(&xonly_pubkey).expect("Should be valid xonlypub key")
+    XOnlyPublicKey::from_slice(&xonly_pubkey).expect("Should be valid xonly pubkey")
 }
 
 pub fn foreign_utxo(value: Amount, index: u32) -> WeightedUtxo {

--- a/wallet/tests/wallet_integration_test.rs
+++ b/wallet/tests/wallet_integration_test.rs
@@ -248,10 +248,12 @@ async fn test_cbf_imported() -> anyhow::Result<()> {
     let mut wallet = BMPWallet::new(env.new_temp_path(), "", Network::Regtest)?;
 
     let prv_keys = [new_private_key(), new_private_key(), new_private_key()];
-    prv_keys.iter().for_each(|e| wallet.import_private_key(*e));
-    prv_keys.iter().for_each(|e| {
+    for e in &prv_keys {
+        wallet.import_private_key(*e);
+    }
+    for e in &prv_keys {
         env.fund_from_prv_key(e, Amount::from_sat(10_000)).unwrap();
-    });
+    }
 
     assert_eq!(wallet.balance(), Amount::from_sat(0));
 
@@ -277,10 +279,12 @@ async fn test_cbf_imported_and_main() -> anyhow::Result<()> {
     env.fund_address(&addr, Amount::from_sat(100_000))?;
 
     let prv_keys = [new_private_key(), new_private_key(), new_private_key()];
-    prv_keys.iter().for_each(|e| wallet.import_private_key(*e));
-    prv_keys.iter().for_each(|e| {
+    for e in &prv_keys {
+        wallet.import_private_key(*e);
+    }
+    for e in &prv_keys {
         env.fund_from_prv_key(e, Amount::from_sat(10_000)).unwrap();
-    });
+    }
 
     assert_eq!(wallet.balance(), Amount::from_sat(0));
 
@@ -366,10 +370,12 @@ async fn test_drain_wallet_with_main_balance() -> anyhow::Result<()> {
     env.fund_address(&addr, amount_to_send_main_wallet)?;
 
     let prv_keys = [new_private_key(), new_private_key()];
-    prv_keys.iter().for_each(|e| wallet.import_private_key(*e));
-    prv_keys.iter().for_each(|e| {
+    for e in &prv_keys {
+        wallet.import_private_key(*e);
+    }
+    for e in &prv_keys {
         env.fund_from_prv_key(e, amount_to_send_imported).unwrap();
-    });
+    }
 
     env.mine_block()?;
     wallet.sync_all(&chain)?;


### PR DESCRIPTION
Make formatting changes to assorted Rust and Java files, to make the latter a little more idiomatic (and compliant with IDEA's autoformatter) and to make the former a little more consistent (at least per file) as well bringing some of the IDE autoformatting slightly closer to rustfmt compatibility (namely spacing around `=`).

Also make some other shallow code cleanup, in particular fixing some mostly-pedantic-level Clippy warnings in the `testenv` and `wallet` packages, so that all the project packages build cleanly with the workspace-configured lints, which are now enabled for all packages.

Additionally, run `cargo update` to bring all the direct dependencies to latest except `electrsd` & `bdk_electrum` (which seem to be difficult to make a major update to without inadvertently enabling AWS-LC in place of Ring for `rustls`), `rusqlite`, `bdk_kyoto` & `bdk_wallet` (which would move BDK to version 3 and presumably be a big change), and `hmac` & `sha2` (for which a major update would prevent reuse of the lagging `hmac` & `sha2` dependencies of `musig2`/`secp`).

In particular `musig2` and `secp` are updated to 0.4 and 0.7 respectively, which is a breaking change requiring some minor changes to the `protocol::multisig` module to incorporate the secret key in the MuSig2 nonce seed. Updating Rust Bitcoin required `FeeRate::from_sat_per_vb_unchecked` to be replaced to prevent deprecation warnings. And `bdk_wallet` is updated to 2.4.0 instead of being pinned to 2.1, now that `bdk_wallet::wallet::signer` has been un-deprecated.

Finally, fix a deadlock in the `testenv` tests when they are run single-threaded, due to the penultimate `TestEnv` instance in `test_persistent_data_dir` needing to be dropped before creating a final `TestEnv` instance.
