### PR TITLE
Refactor compact block filter syncing. Unify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,13 +362,14 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.101"
+version = "0.32.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
+checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
  "bech32",
+ "bitcoin-internals 0.3.0",
  "bitcoin-io 0.1.101",
  "bitcoin-units",
  "bitcoin_hashes 0.14.101",
@@ -389,11 +390,29 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-consensus-encoding"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d7ca3dc8ff835693ad73bf1596240c06f974a31eeb3f611aaedf855f1f2725"
+dependencies = [
+ "bitcoin-internals 0.5.0",
+]
+
+[[package]]
+name = "bitcoin-consensus-encoding"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
 dependencies = [
  "bitcoin-internals 0.5.0",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -417,7 +436,7 @@ version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
 dependencies = [
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
 ]
 
 [[package]]
@@ -435,7 +454,7 @@ version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
 dependencies = [
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 1.0.0",
  "serde",
 ]
 
@@ -466,7 +485,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8a45c2b41c457a9a9e4670422fcbdf109afb3b22bc920b4045e8bdfd788a3d"
 dependencies = [
- "bitcoin-consensus-encoding",
+ "bitcoin-consensus-encoding 0.1.0",
  "bitcoin-internals 0.5.0",
  "hex-conservative 0.3.2",
 ]
@@ -577,9 +596,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bzip2"
@@ -789,18 +808,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -1598,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -2009,6 +2028,7 @@ dependencies = [
  "rand_chacha 0.9.0",
  "testenv",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "wallet",
 ]
@@ -2144,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2156,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2307,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "saa"
@@ -2319,9 +2339,9 @@ checksum = "68f5acb362a0e75c2a963532fa7fabf13dff81626dc494df16488d30befcbea0"
 
 [[package]]
 name = "scc"
-version = "3.8.3"
+version = "3.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5581cd5dd2cb79cbe9d8137071d67f62f0db926e83a07b4d14561c5b7d423776"
+checksum = "7800bc2c7e91b26aeae70c2ab6eaa653efc133104b7756e674c99304adff3fdb"
 dependencies = [
  "saa",
  "sdd",
@@ -3382,18 +3402,18 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,8 +655,8 @@ dependencies = [
  "anyhow",
  "bdk_kyoto",
  "bdk_wallet",
- "bmp_tracing",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_kyoto"
-version = "0.15.4"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f35b9f8b3aa8c4647bec7a92b050c496742d955e0ac1edcb4e7c2deabf63c54"
+checksum = "346c1d502ee4613cf2201db9c3b93a2317772d8eaa372114f34bf5f374be94fd"
 dependencies = [
  "bdk_wallet",
  "bip157",
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_wallet"
-version = "2.4.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99821af39c7df004bd411ece2ef22d9fba5a631b4489f3d9a0ac0d19637e2d0"
+checksum = "1284fb23acc3e3022673712b55f4d5ce7e38aadc2c49bbef830dc3935f0a3289"
 dependencies = [
  "anyhow",
  "bdk_chain",
@@ -325,13 +325,14 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bip157"
-version = "0.3.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88df5c18baaea9be4219679afbd4fc26491606f89f6ecdaffcdcabd67635b07b"
+checksum = "14485468baff5ec4114d186f1683635f3094de9f5a4b3953bf82ac6cccba40e8"
 dependencies = [
  "bip324",
  "bitcoin",
  "bitcoin-address-book",
+ "bitcoin_hashes 0.20.0",
  "tokio",
 ]
 
@@ -456,6 +457,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0982261c82a50d89d1a411602afee0498b3e0debe3d36693f0c661352809639"
 dependencies = [
  "bitcoin-io 0.2.0",
+ "hex-conservative 0.3.2",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8a45c2b41c457a9a9e4670422fcbdf109afb3b22bc920b4045e8bdfd788a3d"
+dependencies = [
+ "bitcoin-consensus-encoding",
+ "bitcoin-internals 0.5.0",
  "hex-conservative 0.3.2",
 ]
 
@@ -622,7 +634,10 @@ name = "chain"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bdk_kyoto",
  "bdk_wallet",
+ "bmp_tracing",
+ "tokio",
 ]
 
 [[package]]
@@ -1983,6 +1998,7 @@ name = "protocol"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bdk_electrum",
  "bdk_wallet",
  "bmp_tracing",
  "chain",
@@ -2632,6 +2648,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "typed-arena",
+ "wallet",
 ]
 
 [[package]]
@@ -2942,6 +2959,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3079,6 +3107,7 @@ dependencies = [
  "testenv",
  "thiserror 2.0.18",
  "tracing",
+ "trait-variant",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ argon2 = { version = "0.5.3", default-features = false }
 base64 = "0.22.1"
 bdk_bitcoind_rpc = "0.22.0"
 bdk_electrum = { version = "0.23.2", default-features = false, features = ["use-rustls-ring"] }
-bdk_kyoto = "0.15.4"
-bdk_wallet = { version = "2.4.0", features = ["rusqlite", "keys-bip39"] }
+bdk_kyoto = "0.17"
+bdk_wallet = { version = "3", features = ["rusqlite", "keys-bip39"] }
 bmp_tracing = { path = "bmp_tracing" }
 chain = { path = "chain" }
 clap = { version = "4.6.1", features = ["derive"] }
@@ -31,6 +31,7 @@ tracing-core = { version = "0.1.36", default-features = false }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 wallet = { path = "wallet" }
 zeroize = "1.9.0"
+trait-variant = "0.1.2"
 
 [workspace.lints.rust]
 rust-2024-compatibility = "warn"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2024"
 [dependencies]
 anyhow = { workspace = true }
 bdk_wallet = { workspace = true }
+tokio = { workspace = true }
+bmp_tracing = { workspace = true }
+bdk_kyoto = { workspace = true }
+
 
 [lints]
 workspace = true

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 anyhow = { workspace = true }
 bdk_wallet = { workspace = true }
 tokio = { workspace = true }
-bmp_tracing = { workspace = true }
+tracing = { workspace = true }
 bdk_kyoto = { workspace = true }
 
 

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -1,8 +1,10 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use bdk_kyoto::bip157::Network;
-use bdk_kyoto::{BuilderExt as _, Info, Receiver, ScanType, UnboundedReceiver, Update, Warning};
+use bdk_kyoto::bip157::{Builder, Network};
+use bdk_kyoto::{
+    BuilderExt as _, Info, Receiver, ScanType, TrustedPeer, UnboundedReceiver, Update, Warning,
+};
 use bdk_wallet::Wallet;
 use bdk_wallet::bitcoin::{Address, Amount, Transaction, Txid};
 use bdk_wallet::chain::DescriptorId;
@@ -37,15 +39,15 @@ pub trait ChainScanner {
     ) -> anyhow::Result<FullScanResponse<K>>;
 }
 
-pub struct CBFScanner;
-
-impl Default for CBFScanner {
-    fn default() -> Self {
-        Self
-    }
+pub struct CBFScanner {
+    pub peers: Vec<TrustedPeer>,
 }
 
 impl CBFScanner {
+    pub const fn new(peers: Vec<TrustedPeer>) -> Self {
+        Self { peers }
+    }
+
     async fn traces(
         mut info_subscriber: Receiver<Info>,
         mut warning_subscriber: UnboundedReceiver<Warning>,
@@ -77,13 +79,17 @@ impl CBFScanner {
     pub async fn sync_cbf(
         &self,
         network: Network,
+        peers: Vec<TrustedPeer>,
         wallets: Vec<(&Wallet, ScanType)>,
     ) -> anyhow::Result<BTreeMap<DescriptorId, Update>> {
-        let client = bdk_kyoto::bip157::Builder::new(network).build_with_wallets(wallets)?;
+        let client = Builder::new(network)
+            .add_peers(peers)
+            .build_with_wallets(wallets)?;
 
         let (client, logging, mut update_subscriber) = client.subscribe();
+
         tokio::task::spawn(async move {
-            Self::traces(logging.info_subscriber, logging.warning_subscriber).await
+            Self::traces(logging.info_subscriber, logging.warning_subscriber).await;
         });
         let client = client.start();
         let requester = client.requester();

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -1,12 +1,21 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use bdk_wallet::bitcoin::{Transaction, Txid};
+use bdk_kyoto::bip157::Network;
+use bdk_kyoto::{BuilderExt as _, Info, Receiver, ScanType, UnboundedReceiver, Update, Warning};
+use bdk_wallet::Wallet;
+use bdk_wallet::bitcoin::{Address, Amount, Transaction, Txid};
+use bdk_wallet::chain::DescriptorId;
 use bdk_wallet::chain::spk_client::{FullScanRequest, FullScanResponse};
+use bmp_tracing::tracing;
+use tokio::select;
 
 /// Abstraction over blockchain interaction for broadcasting transactions.
 /// to be extended
 pub trait ChainApi: Send + Sync {
     fn transaction_broadcast(&self, tx: &Transaction) -> anyhow::Result<Txid>;
+    fn send_to_address(&self, address: &Address, amount: Amount) -> anyhow::Result<()>;
+    fn generate_to_address(&self, blocks: u32, address: &Address) -> anyhow::Result<()>;
 }
 
 /// Abstraction over the read-side of a chain backend: pre-populating a transaction cache and
@@ -26,4 +35,81 @@ pub trait ChainScanner {
         batch_size: usize,
         fetch_prev_txouts: bool,
     ) -> anyhow::Result<FullScanResponse<K>>;
+}
+
+pub struct CBFScanner;
+
+impl Default for CBFScanner {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl CBFScanner {
+    async fn traces(
+        mut info_subscriber: Receiver<Info>,
+        mut warning_subscriber: UnboundedReceiver<Warning>,
+    ) {
+        loop {
+            select! {
+                info = info_subscriber.recv() => {
+                    if let Some(info) = info {
+                        match info {
+                            Info::Progress(p) => {
+                                tracing::info!("chain height: {}, filter download progress: {}%", p.chain_height(), p.percentage_complete());
+                            },
+                            Info::BlockReceived(b) => {
+                                tracing::info!("downloaded block: {b}");
+                            },
+                            _ => (),
+                        }
+                    }
+                }
+                warn = warning_subscriber.recv() => {
+                    if let Some(warn) = warn {
+                        tracing::warn!("{warn}");
+                    }
+                }
+            }
+        }
+    }
+
+    pub async fn sync_cbf(
+        &self,
+        network: Network,
+        wallets: Vec<(&Wallet, ScanType)>,
+    ) -> anyhow::Result<BTreeMap<DescriptorId, Update>> {
+        let client = bdk_kyoto::bip157::Builder::new(network).build_with_wallets(wallets)?;
+
+        let (client, logging, mut update_subscriber) = client.subscribe();
+        tokio::task::spawn(async move {
+            Self::traces(logging.info_subscriber, logging.warning_subscriber).await
+        });
+        let client = client.start();
+        let requester = client.requester();
+        // Updates are grouped with the `DescriptorId` of the public, external descriptor.
+        let updates = update_subscriber
+            .updates()
+            .await?
+            .collect::<BTreeMap<_, _>>();
+
+        requester.shutdown()?;
+        Ok(updates)
+    }
+}
+
+impl ChainScanner for CBFScanner {
+    fn full_scan<K: Ord + Clone>(
+        &self,
+        _request: impl Into<FullScanRequest<K>>,
+        _stop_gap: usize,
+        _batch_size: usize,
+        _fetch_prev_txouts: bool,
+    ) -> anyhow::Result<FullScanResponse<K>> {
+        todo!("Not implemented");
+    }
+
+    fn populate_tx_cache(&self, _txs: impl IntoIterator<Item = impl Into<Arc<Transaction>>>) {
+        todo!("Not implemented");
+    }
 }

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -9,7 +9,6 @@ use bdk_wallet::Wallet;
 use bdk_wallet::bitcoin::{Address, Amount, Transaction, Txid};
 use bdk_wallet::chain::DescriptorId;
 use bdk_wallet::chain::spk_client::{FullScanRequest, FullScanResponse};
-use bmp_tracing::tracing;
 use tokio::select;
 
 /// Abstraction over blockchain interaction for broadcasting transactions.
@@ -112,10 +111,10 @@ impl ChainScanner for CBFScanner {
         _batch_size: usize,
         _fetch_prev_txouts: bool,
     ) -> anyhow::Result<FullScanResponse<K>> {
-        todo!("Not implemented");
+        unimplemented!("Not implemented");
     }
 
     fn populate_tx_cache(&self, _txs: impl IntoIterator<Item = impl Into<Arc<Transaction>>>) {
-        todo!("Not implemented");
+        unimplemented!("Not implemented");
     }
 }

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -10,11 +10,12 @@ use bdk_wallet::bitcoin::{Address, Amount, Transaction, Txid};
 use bdk_wallet::chain::DescriptorId;
 use bdk_wallet::chain::spk_client::{FullScanRequest, FullScanResponse};
 use tokio::select;
-
-/// Abstraction over blockchain interaction for broadcasting transactions.
-/// to be extended
+/// Minimal abstraction over blockchain interaction for broadcasting transactions.
 pub trait ChainApi: Send + Sync {
     fn transaction_broadcast(&self, tx: &Transaction) -> anyhow::Result<Txid>;
+}
+/// Optional funding helpers used by the wallet test bootstrap path.
+pub trait ChainFunding: Send + Sync {
     fn send_to_address(&self, address: &Address, amount: Amount) -> anyhow::Result<()>;
     fn generate_to_address(&self, blocks: u32, address: &Address) -> anyhow::Result<()>;
 }
@@ -64,11 +65,15 @@ impl CBFScanner {
                             },
                             _ => (),
                         }
+                    } else {
+                        break;
                     }
                 }
                 warn = warning_subscriber.recv() => {
                     if let Some(warn) = warn {
                         tracing::warn!("{warn}");
+                    } else {
+                        break;
                     }
                 }
             }
@@ -100,21 +105,5 @@ impl CBFScanner {
 
         requester.shutdown()?;
         Ok(updates)
-    }
-}
-
-impl ChainScanner for CBFScanner {
-    fn full_scan<K: Ord + Clone>(
-        &self,
-        _request: impl Into<FullScanRequest<K>>,
-        _stop_gap: usize,
-        _batch_size: usize,
-        _fetch_prev_txouts: bool,
-    ) -> anyhow::Result<FullScanResponse<K>> {
-        unimplemented!("Not implemented");
-    }
-
-    fn populate_tx_cache(&self, _txs: impl IntoIterator<Item = impl Into<Arc<Transaction>>>) {
-        unimplemented!("Not implemented");
     }
 }

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -18,8 +18,10 @@ wallet = { workspace = true }
 
 [dev-dependencies]
 bdk_wallet = { workspace = true, features = ["test-utils"] }
+bdk_electrum = { workspace = true }
 bmp_tracing = { workspace = true }
 const_format = { workspace = true }
+tokio = { workspace = true }
 testenv = { workspace = true }
 
 [lints]

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -11,6 +11,7 @@ musig2 = { workspace = true }
 paste = "1.0.15"
 rand = { workspace = true }
 rand_chacha = { workspace = true }
+
 thiserror = { workspace = true }
 tracing = { workspace = true }
 wallet = { workspace = true }

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -11,7 +11,6 @@ musig2 = { workspace = true }
 paste = "1.0.15"
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-
 thiserror = { workspace = true }
 tracing = { workspace = true }
 wallet = { workspace = true }

--- a/protocol/tests/protocol_integration_tests.rs
+++ b/protocol/tests/protocol_integration_tests.rs
@@ -1,3 +1,5 @@
+use bdk_electrum::BdkElectrumClient;
+use bdk_electrum::electrum_client::Client as ElectrumClient;
 use bdk_wallet::bitcoin;
 use bdk_wallet::rusqlite::Connection;
 use bitcoin::key::{Keypair, Secp256k1, TapTweak as _, TweakedKeypair, TweakedPublicKey};
@@ -10,6 +12,7 @@ use protocol::protocol_musig_adaptor::{BMPContext, BMPProtocol, ProtocolRole};
 use protocol::psbt::BoxedTradeWallet;
 use protocol::transaction::{CustomPayoutTxBuilder, TransactionExt as _};
 use testenv::TestEnv;
+use tokio::runtime::Runtime;
 use wallet::bmp_wallet::{BMPWallet, WalletApi as _};
 use wallet::protocol_wallet_api::MemWallet;
 
@@ -32,7 +35,7 @@ pub fn funded_wallet(env: &mut TestEnv) -> BoxedTradeWallet {
         .to_ascii_lowercase()
         .as_str()
     {
-        "mem" => Box::new(MemWallet::funded_wallet(env)),
+        "mem" => Box::new(funded_mem_wallet(env)),
         "bmp" => Box::new(funded_bmp_wallet(env)),
         other => panic!("unknown WALLET_BACKEND={other:?}, expected `mem` or `bmp`"),
     }
@@ -50,7 +53,22 @@ fn funded_bmp_wallet(env: &mut TestEnv) -> BMPWallet<Connection> {
     env.wait_for_tx(txid).unwrap();
 
     let chain = env.new_testchain().unwrap();
-    wallet.sync_all(&chain).unwrap();
+    let rt = Runtime::new().expect("create runtime");
+    rt.block_on(async { wallet.sync_all(&chain).await })
+        .unwrap();
+    wallet
+}
+
+fn funded_mem_wallet(env: &mut TestEnv) -> MemWallet {
+    let client = BdkElectrumClient::new(ElectrumClient::new(&env.electrum_url()).unwrap());
+    let mut wallet = MemWallet::new(client).unwrap();
+    let address = wallet.next_unused_address();
+    let txid = env
+        .fund_address(&address.address, Amount::from_btc(10f64).unwrap())
+        .unwrap();
+    env.mine_block().unwrap();
+    env.wait_for_tx(txid).unwrap();
+    wallet.sync().unwrap();
     wallet
 }
 

--- a/rpc/tests/bmp_service.rs
+++ b/rpc/tests/bmp_service.rs
@@ -16,10 +16,11 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client as BitcoinCoreClient, RpcApi as _};
+use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client as BitcoinCoreClient};
 use bdk_electrum::BdkElectrumClient;
 use bdk_electrum::electrum_client::Client as ElectrumClient;
-use bdk_wallet::bitcoin::Amount;
+use bdk_wallet::bitcoin::{Address, Amount, Transaction, Txid};
+use chain::ChainApi;
 use protocol::protocol_musig_adaptor::{BMPContext, BMPProtocol, ProtocolRole, Round1Parameter};
 use rpc::bmp_wallet_service::BmpWalletServiceImpl;
 use rpc::pb::bmp_protocol::bmp_protocol_service_server::{
@@ -38,53 +39,47 @@ use tonic::{Request, Response, Result, Status, transport};
 use tracing::info;
 use wallet::protocol_wallet_api::MemWallet;
 
+struct BitcoinCoreChainApi {
+    client: Arc<BitcoinCoreClient>,
+}
+
+impl ChainApi for BitcoinCoreChainApi {
+    fn transaction_broadcast(&self, _tx: &Transaction) -> anyhow::Result<Txid> {
+        anyhow::bail!("transaction broadcast is not used in this test helper")
+    }
+
+    fn send_to_address(&self, address: &Address, amount: Amount) -> anyhow::Result<()> {
+        bdk_bitcoind_rpc::bitcoincore_rpc::RpcApi::send_to_address(
+            self.client.as_ref(),
+            address,
+            amount,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .map(|_| ())
+        .map_err(Into::into)
+    }
+
+    fn generate_to_address(&self, blocks: u32, address: &Address) -> anyhow::Result<()> {
+        bdk_bitcoind_rpc::bitcoincore_rpc::RpcApi::generate_to_address(
+            self.client.as_ref(),
+            blocks.into(),
+            address,
+        )
+        .map(|_| ())
+        .map_err(Into::into)
+    }
+}
+
 pub struct BmpServiceImpl {
     // Each trade protocol is stored against a unique ID.
     active_protocols: Mutex<HashMap<String, BMPProtocol>>,
     bitcoin_rpc_client: Arc<BitcoinCoreClient>,
     electrum_url: String,
-}
-
-fn funded_wallet_from_rpc(
-    rpc: &BitcoinCoreClient,
-    client: BdkElectrumClient<ElectrumClient>,
-) -> anyhow::Result<MemWallet> {
-    const MAX_RETRIES: u32 = 20;
-    const RETRY_DELAY_MS: u64 = 500;
-
-    let mut wallet = MemWallet::new(client)?;
-    let address = wallet.reveal_next_address();
-    rpc.send_to_address(
-        &address,
-        Amount::from_btc(10f64).unwrap(),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    )?;
-    rpc.generate_to_address(1, &address)?;
-
-    for attempt in 0..MAX_RETRIES {
-        wallet.sync()?;
-        if wallet.balance() > Amount::from_sat(0) {
-            info!("Wallet funded after {} retries", attempt);
-            return Ok(wallet);
-        }
-        if attempt < MAX_RETRIES - 1 {
-            info!(
-                "Wallet still unfunded, attempt {}/{}, retrying...",
-                attempt + 1,
-                MAX_RETRIES
-            );
-            std::thread::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS));
-        }
-    }
-
-    Err(anyhow::anyhow!(
-        "Wallet failed to sync funded balance after {MAX_RETRIES} attempts"
-    ))
 }
 
 impl BmpServiceImpl {
@@ -109,7 +104,10 @@ impl BmpProtocolService for BmpServiceImpl {
         let client = BdkElectrumClient::new(ElectrumClient::new(&self.electrum_url).unwrap());
         let client2 = BdkElectrumClient::new(ElectrumClient::new(&self.electrum_url).unwrap());
 
-        let mock_wallet = funded_wallet_from_rpc(self.bitcoin_rpc_client.as_ref(), client)
+        let chain_api = BitcoinCoreChainApi {
+            client: self.bitcoin_rpc_client.clone(),
+        };
+        let mock_wallet = MemWallet::funded_wallet_from_rpc(&chain_api, client)
             .map_err(|e: anyhow::Error| Status::internal(e.to_string()))?;
 
         info!(

--- a/rpc/tests/bmp_service.rs
+++ b/rpc/tests/bmp_service.rs
@@ -19,8 +19,8 @@ use std::sync::{Arc, Mutex};
 use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client as BitcoinCoreClient};
 use bdk_electrum::BdkElectrumClient;
 use bdk_electrum::electrum_client::Client as ElectrumClient;
-use bdk_wallet::bitcoin::{Address, Amount, Transaction, Txid};
-use chain::ChainApi;
+use bdk_wallet::bitcoin::{Address, Amount};
+use chain::ChainFunding;
 use protocol::protocol_musig_adaptor::{BMPContext, BMPProtocol, ProtocolRole, Round1Parameter};
 use rpc::bmp_wallet_service::BmpWalletServiceImpl;
 use rpc::pb::bmp_protocol::bmp_protocol_service_server::{
@@ -43,11 +43,7 @@ struct BitcoinCoreChainApi {
     client: Arc<BitcoinCoreClient>,
 }
 
-impl ChainApi for BitcoinCoreChainApi {
-    fn transaction_broadcast(&self, _tx: &Transaction) -> anyhow::Result<Txid> {
-        anyhow::bail!("transaction broadcast is not used in this test helper")
-    }
-
+impl ChainFunding for BitcoinCoreChainApi {
     fn send_to_address(&self, address: &Address, amount: Amount) -> anyhow::Result<()> {
         bdk_bitcoind_rpc::bitcoincore_rpc::RpcApi::send_to_address(
             self.client.as_ref(),

--- a/testenv/Cargo.toml
+++ b/testenv/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = { workspace = true }
 bdk_bitcoind_rpc = { workspace = true }
 bdk_electrum = { workspace = true }
 bdk_wallet = { workspace = true, features = ["test-utils"] }
+wallet = { path = "../wallet"}
 bmp_tracing = { workspace = true }
 chain = { workspace = true }
 clap = { workspace = true }

--- a/testenv/src/lib.rs
+++ b/testenv/src/lib.rs
@@ -11,15 +11,14 @@ use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, RpcApi as _};
 use bdk_electrum::BdkElectrumClient;
 use bdk_electrum::bdk_core::bitcoin::{KnownHrp, XOnlyPublicKey};
 use bdk_electrum::electrum_client::Error;
-use bdk_wallet::PersistedWallet;
 use bdk_wallet::bitcoin::address::NetworkChecked;
 use bdk_wallet::bitcoin::key::Secp256k1;
 use bdk_wallet::bitcoin::secp256k1::All;
 use bdk_wallet::bitcoin::{Address, Amount, BlockHash, Network, Transaction, Txid};
 use bdk_wallet::chain::spk_client::{FullScanRequest, FullScanResponse};
-use bdk_wallet::serde_json;
+use bdk_wallet::{PersistedWallet, serde_json};
 use bmp_tracing::tracing;
-use chain::{ChainApi, ChainScanner};
+use chain::{ChainApi, ChainFunding, ChainScanner};
 use electrsd::corepc_node::Node;
 use electrsd::electrum_client::{Client, ElectrumApi};
 use electrsd::{ElectrsD, corepc_node};
@@ -681,7 +680,9 @@ impl ChainApi for Testchain {
     fn transaction_broadcast(&self, tx: &Transaction) -> Result<Txid> {
         broadcast_via(&self.client, tx)
     }
+}
 
+impl ChainFunding for Testchain {
     fn send_to_address(&self, _address: &Address, _amount: Amount) -> Result<()> {
         anyhow::bail!("send_to_address is not implemented for Testchain")
     }

--- a/testenv/src/lib.rs
+++ b/testenv/src/lib.rs
@@ -11,6 +11,7 @@ use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, RpcApi as _};
 use bdk_electrum::BdkElectrumClient;
 use bdk_electrum::bdk_core::bitcoin::{KnownHrp, XOnlyPublicKey};
 use bdk_electrum::electrum_client::Error;
+use bdk_wallet::PersistedWallet;
 use bdk_wallet::bitcoin::address::NetworkChecked;
 use bdk_wallet::bitcoin::key::Secp256k1;
 use bdk_wallet::bitcoin::secp256k1::All;
@@ -29,6 +30,8 @@ use sha2::Sha256;
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 use typed_arena::Arena;
+use wallet::bmp_wallet::BMPWalletPersister;
+use wallet::chain_data_source::ChainDataSource;
 
 /// Bitcoin regtest environment manager
 pub struct TestEnv {
@@ -678,6 +681,22 @@ impl ChainApi for Testchain {
     fn transaction_broadcast(&self, tx: &Transaction) -> Result<Txid> {
         broadcast_via(&self.client, tx)
     }
+
+    fn send_to_address(
+        &self,
+        _address: &bdk_wallet::bitcoin::Address,
+        _amount: bdk_wallet::bitcoin::Amount,
+    ) -> anyhow::Result<()> {
+        anyhow::bail!("send_to_address is not implemented for Testchain")
+    }
+
+    fn generate_to_address(
+        &self,
+        _blocks: u32,
+        _address: &bdk_wallet::bitcoin::Address,
+    ) -> anyhow::Result<()> {
+        anyhow::bail!("generate_to_address is not implemented for Testchain")
+    }
 }
 
 impl ChainScanner for Testchain {
@@ -695,6 +714,33 @@ impl ChainScanner for Testchain {
         self.client
             .full_scan(request, stop_gap, batch_size, fetch_prev_txouts)
             .map_err(Into::into)
+    }
+}
+
+/// `ChainDataSource` implementation for the Electrum-backed [`testenv::Testchain`] handle.
+///
+/// `Testchain` lives in the `testenv` crate alongside `TestEnv`; this impl ties it into the
+/// wallet's sync routine. It mirrors the values previously used by the live Electrum-backed
+/// implementation.
+impl ChainDataSource for Testchain {
+    const RECOVERY_HEIGHT: usize = 190_000;
+    const BATCH_SIZE: usize = 16;
+    const STOP_GAP: usize = 10;
+
+    async fn sync(
+        &self,
+        persister: Vec<&mut PersistedWallet<impl BMPWalletPersister>>,
+    ) -> anyhow::Result<()> {
+        for wallet in persister {
+            let tx_nodes = wallet.tx_graph().full_txs().map(|tx_node| tx_node.tx);
+            self.populate_tx_cache(tx_nodes);
+            let request = wallet.start_full_scan();
+
+            let updates = self.full_scan(request, Self::STOP_GAP, Self::BATCH_SIZE, false)?;
+
+            wallet.apply_update(updates)?;
+        }
+        Ok(())
     }
 }
 

--- a/testenv/src/lib.rs
+++ b/testenv/src/lib.rs
@@ -682,19 +682,11 @@ impl ChainApi for Testchain {
         broadcast_via(&self.client, tx)
     }
 
-    fn send_to_address(
-        &self,
-        _address: &bdk_wallet::bitcoin::Address,
-        _amount: bdk_wallet::bitcoin::Amount,
-    ) -> anyhow::Result<()> {
+    fn send_to_address(&self, _address: &Address, _amount: Amount) -> Result<()> {
         anyhow::bail!("send_to_address is not implemented for Testchain")
     }
 
-    fn generate_to_address(
-        &self,
-        _blocks: u32,
-        _address: &bdk_wallet::bitcoin::Address,
-    ) -> anyhow::Result<()> {
+    fn generate_to_address(&self, _blocks: u32, _address: &Address) -> Result<()> {
         anyhow::bail!("generate_to_address is not implemented for Testchain")
     }
 }
@@ -730,7 +722,7 @@ impl ChainDataSource for Testchain {
     async fn sync(
         &self,
         persister: Vec<&mut PersistedWallet<impl BMPWalletPersister>>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<()> {
         for wallet in persister {
             let tx_nodes = wallet.tx_graph().full_txs().map(|tx_node| tx_node.tx);
             self.populate_tx_cache(tx_nodes);

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -17,14 +17,11 @@ rusqlite = { workspace = true }
 secp = { workspace = true }
 tracing = { workspace = true }
 zeroize = { workspace = true }
-thiserror = { workspace = true }
-# TODO move this to dev-dependencies:
-testenv = { workspace = true }
+thiserror =  { workspace = true }
+trait-variant = { workspace =  true }
 
 [dev-dependencies]
 bdk_wallet = { workspace = true, features = ["test-utils"] }
 bmp_tracing = { workspace = true }
 tempfile = { workspace = true }
-
-[lints]
-workspace = true
+testenv = { path = "../testenv" }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -24,4 +24,7 @@ trait-variant = { workspace =  true }
 bdk_wallet = { workspace = true, features = ["test-utils"] }
 bmp_tracing = { workspace = true }
 tempfile = { workspace = true }
-testenv = { path = "../testenv" }
+testenv = { path = "../testenv"}
+
+[lints]
+workspace = true

--- a/wallet/src/bmp_wallet.rs
+++ b/wallet/src/bmp_wallet.rs
@@ -364,12 +364,12 @@ pub trait WalletApi {
     fn drain_imported_balance(&mut self, fee_rate: FeeRate) -> anyhow::Result<Psbt>;
 }
 
-fn get_imported_wallets(
+pub fn get_imported_wallets(
     imported_keys: &Vec<Scalar>,
     db: &Connection,
     network: Network,
     db_name: &str,
-) -> anyhow::Result<Vec<PersistedWallet<Connection>>> {
+) -> anyhow::Result<Vec<(PersistedWallet<Connection>, Connection)>> {
     let mut res = vec![];
     for key in imported_keys {
         let pbk = key.base_point_mul();
@@ -378,7 +378,7 @@ fn get_imported_wallets(
             .path()
             .expect("DB path should not be empty")
             .replace(db_name, "");
-        let db_path = Path::new(&path_str).join(format!("bmp_{}.db3", pubk));
+        let db_path = Path::new(&path_str).join(format!("bmp_{pubk}.db3"));
 
         let mut db = Connection::open(db_path)?;
         let imported_wallet_opt = Wallet::load()
@@ -396,7 +396,7 @@ fn get_imported_wallets(
                     .create_wallet(&mut db)?
             }
         };
-        res.push(imported_wallet)
+        res.push((imported_wallet, db))
     }
     Ok(res)
 }
@@ -414,8 +414,34 @@ impl WalletApi for BMPWallet<Connection> {
         let mut vec = vec![&mut self.wallet];
         let mut imported =
             get_imported_wallets(&self.imported_keys, &self.db, network, Self::DB_NAME)?;
-        vec.extend(imported.iter_mut());
-        s.sync(vec).await
+
+        vec.extend(
+            imported
+                .iter_mut()
+                .map(|persister_wallet| &mut persister_wallet.0),
+        );
+
+        s.sync(vec).await?;
+
+        let mut final_imported_balance = Balance::default();
+
+        // For having accurate Wallet::calculate_fee and Wallet::calculate_fee_rate
+        for (w, _) in &imported {
+            for utxo in w.list_unspent() {
+                self.insert_txout(utxo.outpoint, utxo.txout);
+            }
+            final_imported_balance = final_imported_balance + w.balance();
+        }
+
+        self.imported_balance = final_imported_balance;
+
+        // Persist changes from imported keys
+        for (w, db) in imported.iter_mut() {
+            w.persist(db)?;
+        }
+
+        let _ = self.persist();
+        Ok(())
     }
 
     fn new(path: &Path, password: &str, network: Network) -> anyhow::Result<Self>

--- a/wallet/src/bmp_wallet.rs
+++ b/wallet/src/bmp_wallet.rs
@@ -431,7 +431,7 @@ impl WalletApi for BMPWallet<Connection> {
             w.persist(db)?;
         }
 
-        let _ = self.persist();
+        self.persist()?;
         Ok(())
     }
 

--- a/wallet/src/bmp_wallet.rs
+++ b/wallet/src/bmp_wallet.rs
@@ -356,10 +356,7 @@ pub trait WalletApi {
         sign_options: SignOptions,
     ) -> anyhow::Result<(), SignerError>;
 
-    async fn sync_all(
-        &mut self,
-        s: &(impl ChainDataSource + std::marker::Sync),
-    ) -> anyhow::Result<()>;
+    async fn sync_all(&mut self, s: &(impl ChainDataSource + Sync)) -> anyhow::Result<()>;
 
     fn drain_imported_balance(&mut self, fee_rate: FeeRate) -> anyhow::Result<Psbt>;
 }
@@ -372,8 +369,8 @@ pub fn get_imported_wallets(
 ) -> anyhow::Result<Vec<(PersistedWallet<Connection>, Connection)>> {
     let mut res = vec![];
     for key in imported_keys {
-        let pbk = key.base_point_mul();
-        let pubk = pbk.serialize_xonly().to_lower_hex_string();
+        let pubk = key.base_point_mul();
+        let pubk = pubk.serialize_xonly().to_lower_hex_string();
         let path_str = db
             .path()
             .expect("DB path should not be empty")
@@ -386,17 +383,14 @@ pub fn get_imported_wallets(
             .extract_keys()
             .load_wallet(&mut db)?;
 
-        let imported_wallet = match imported_wallet_opt {
-            Some(wallet) => wallet,
-            None => {
-                let descriptor = format!("tr({})", pubk);
+        let imported_wallet = if let Some(wallet) = imported_wallet_opt { wallet } else {
+            let descriptor = format!("tr({pubk})");
 
-                Wallet::create_single(descriptor)
-                    .network(network)
-                    .create_wallet(&mut db)?
-            }
+            Wallet::create_single(descriptor)
+                .network(network)
+                .create_wallet(&mut db)?
         };
-        res.push((imported_wallet, db))
+        res.push((imported_wallet, db));
     }
     Ok(res)
 }
@@ -406,10 +400,7 @@ impl WalletApi for BMPWallet<Connection> {
     const IMPORTED_KEYS_TABLE_NAME: &'static str = "bmp_imported_keys";
     const DB_NAME: &str = "bmp_bdk_wallet.db3";
 
-    async fn sync_all(
-        &mut self,
-        s: &(impl ChainDataSource + std::marker::Sync),
-    ) -> Result<(), anyhow::Error> {
+    async fn sync_all(&mut self, s: &(impl ChainDataSource + Sync)) -> Result<(), anyhow::Error> {
         let network = self.network();
         let mut vec = vec![&mut self.wallet];
         let mut imported =
@@ -436,7 +427,7 @@ impl WalletApi for BMPWallet<Connection> {
         self.imported_balance = final_imported_balance;
 
         // Persist changes from imported keys
-        for (w, db) in imported.iter_mut() {
+        for (w, db) in &mut imported {
             w.persist(db)?;
         }
 

--- a/wallet/src/bmp_wallet.rs
+++ b/wallet/src/bmp_wallet.rs
@@ -5,8 +5,6 @@ use std::{fs, vec};
 use base64::Engine as _;
 use base64::engine::general_purpose;
 use bdk_electrum::bdk_core::bitcoin::{Address, FeeRate, OutPoint};
-use bdk_kyoto::bip157::{Builder, tokio};
-use bdk_kyoto::{BuilderExt as _, LightClient, Requester, ScanType, TrustedPeer, UpdateSubscriber};
 use bdk_wallet::bitcoin::bip32::Xpriv;
 use bdk_wallet::bitcoin::hex::DisplayHex as _;
 use bdk_wallet::bitcoin::{
@@ -31,7 +29,7 @@ use crate::protocol_wallet_api::{
     ProtocolWalletApi, WalletExt, finish_standard_psbt, internal_key_at_index,
     sign_selected_inputs_with,
 };
-use crate::utils::{derive_key_from_password, get_salt, trace_logs};
+use crate::utils::{derive_key_from_password, get_salt};
 
 pub trait BMPWalletPersister: WalletPersister {
     type DB;
@@ -236,37 +234,6 @@ impl BMPWallet<Connection> {
         self.imported_keys.push(pk);
     }
 
-    /// Helper function to run a CBF node
-    /// This will:
-    /// - Create a new Light client
-    /// - spawn two tasks, one for trace logs and another for the server node
-    /// - Return the requester and the subscriber from which the updates can be pulled
-    ///
-    /// Note: The caller is responsible for shutting down the requester at will.
-    ///
-    /// # Panics
-    /// Will panic if called outside the context of a Tokio runtime
-    pub fn run_node(
-        wallet: &Wallet,
-        scan_type: ScanType,
-        peers: Vec<TrustedPeer>,
-    ) -> anyhow::Result<(Requester, UpdateSubscriber)> {
-        let LightClient {
-            requester,
-            info_subscriber,
-            warning_subscriber,
-            update_subscriber,
-            node,
-        } = Builder::new(wallet.network())
-            .add_peers(peers)
-            .build_with_wallet(wallet, scan_type)?;
-
-        tokio::task::spawn(async move { node.run().await });
-        // Trace the logs with a custom function.
-        tokio::task::spawn(async move { trace_logs(info_subscriber, warning_subscriber).await });
-        Ok((requester, update_subscriber))
-    }
-
     fn imported_utxos(&self) -> Vec<WeightedUtxo> {
         let secp: &bdk_wallet::bitcoin::key::Secp256k1<bdk_wallet::bitcoin::secp256k1::All> =
             self.secp_ctx();
@@ -358,6 +325,7 @@ impl ProtocolWalletApi for BMPWallet<Connection> {
     }
 }
 
+#[trait_variant::make(Send)]
 pub trait WalletApi {
     const DB_NAME: &str;
     const SEEDS_TABLE_NAME: &'static str;
@@ -388,25 +356,67 @@ pub trait WalletApi {
         sign_options: SignOptions,
     ) -> anyhow::Result<(), SignerError>;
 
-    fn sync_all(&mut self, data_source: &impl ChainDataSource) -> anyhow::Result<bool>;
-    fn sync_cbf(
+    async fn sync_all(
         &mut self,
-        scan_type: ScanType,
-        peers: Vec<TrustedPeer>,
-    ) -> impl Future<Output = anyhow::Result<()>> + Send;
-    fn sync_cbf_imported(
-        &mut self,
-        scan_type: ScanType,
-        peers: Vec<TrustedPeer>,
-    ) -> impl Future<Output = anyhow::Result<()>> + Send;
+        s: &(impl ChainDataSource + std::marker::Sync),
+    ) -> anyhow::Result<()>;
 
     fn drain_imported_balance(&mut self, fee_rate: FeeRate) -> anyhow::Result<Psbt>;
+}
+
+fn get_imported_wallets(
+    imported_keys: &Vec<Scalar>,
+    db: &Connection,
+    network: Network,
+    db_name: &str,
+) -> anyhow::Result<Vec<PersistedWallet<Connection>>> {
+    let mut res = vec![];
+    for key in imported_keys {
+        let pbk = key.base_point_mul();
+        let pubk = pbk.serialize_xonly().to_lower_hex_string();
+        let path_str = db
+            .path()
+            .expect("DB path should not be empty")
+            .replace(db_name, "");
+        let db_path = Path::new(&path_str).join(format!("bmp_{}.db3", pubk));
+
+        let mut db = Connection::open(db_path)?;
+        let imported_wallet_opt = Wallet::load()
+            .check_network(network)
+            .extract_keys()
+            .load_wallet(&mut db)?;
+
+        let imported_wallet = match imported_wallet_opt {
+            Some(wallet) => wallet,
+            None => {
+                let descriptor = format!("tr({})", pubk);
+
+                Wallet::create_single(descriptor)
+                    .network(network)
+                    .create_wallet(&mut db)?
+            }
+        };
+        res.push(imported_wallet)
+    }
+    Ok(res)
 }
 
 impl WalletApi for BMPWallet<Connection> {
     const SEEDS_TABLE_NAME: &'static str = "bmp_seeds";
     const IMPORTED_KEYS_TABLE_NAME: &'static str = "bmp_imported_keys";
     const DB_NAME: &str = "bmp_bdk_wallet.db3";
+
+    async fn sync_all(
+        &mut self,
+        s: &(impl ChainDataSource + std::marker::Sync),
+    ) -> Result<(), anyhow::Error> {
+        let network = self.network();
+        let mut vec = vec![&mut self.wallet];
+        let mut imported =
+            get_imported_wallets(&self.imported_keys, &self.db, network, Self::DB_NAME)?;
+        vec.extend(imported.iter_mut());
+        s.sync(vec).await
+    }
 
     fn new(path: &Path, password: &str, network: Network) -> anyhow::Result<Self>
     where
@@ -418,9 +428,10 @@ impl WalletApi for BMPWallet<Connection> {
 
         let xprv = Xpriv::new_master(network, &seed)?;
 
-        let (descriptor, external_map, _) = Bip86(xprv, KeychainKind::External).build(network)?;
+        let (descriptor, external_map, _) =
+            Bip86(xprv, KeychainKind::External).build(network.into())?;
         let (change_descriptor, internal_map, _) =
-            Bip86(xprv, KeychainKind::Internal).build(network)?;
+            Bip86(xprv, KeychainKind::Internal).build(network.into())?;
 
         let db_path = path.join(Self::DB_NAME);
         let db_path = db_path.to_str().expect("Should get path value");
@@ -533,11 +544,11 @@ impl WalletApi for BMPWallet<Connection> {
                 .map_err(|_| SignerError::External("Unable to load keys".to_owned()))?;
 
             let (_, external_map, _) = Bip86(xprv, KeychainKind::External)
-                .build(self.network())
+                .build(self.network().into())
                 .map_err(|_| SignerError::External("BIP 86 derivation failed".to_owned()))?;
 
             let (_, internal_map, _) = Bip86(xprv, KeychainKind::Internal)
-                .build(self.network())
+                .build(self.network().into())
                 .map_err(|_| SignerError::External("BIP 86 derivation failed".to_owned()))?;
 
             self.wallet.set_keymap(KeychainKind::External, external_map);
@@ -551,135 +562,6 @@ impl WalletApi for BMPWallet<Connection> {
         let _finalized = self.wallet.sign(psbt, sign_options)?;
 
         Ok(())
-    }
-
-    async fn sync_cbf(
-        &mut self,
-        scan_type: ScanType,
-        peers: Vec<TrustedPeer>,
-    ) -> anyhow::Result<()> {
-        let (requester, mut updates_sub) = Self::run_node(self, scan_type, peers)?;
-        let updates = updates_sub.update().await?;
-
-        self.apply_update(updates)?;
-        self.persist()?;
-
-        requester.shutdown()?;
-        Ok(())
-    }
-
-    /// Sync the imported keys from protocol using CBF
-    async fn sync_cbf_imported(
-        &mut self,
-        scan_type: ScanType,
-        peers: Vec<TrustedPeer>,
-    ) -> anyhow::Result<()> {
-        struct KeyEntry {
-            db: Connection,
-            wallet: PersistedWallet<Connection>,
-            update_subscriber: UpdateSubscriber,
-            requester: Requester,
-        }
-
-        let pubkeys = self
-            .imported_keys
-            .iter()
-            .map(|s| s.base_point_mul().serialize_xonly())
-            .collect::<Vec<_>>();
-
-        // Build all wallets and light clients upfront, then run all nodes concurrently
-        // so their peer connections overlap (gossip addresses from one benefit the others).
-        let mut entries: Vec<KeyEntry> = Vec::with_capacity(pubkeys.len());
-        for key in &pubkeys {
-            let path_str = self.db.path().expect("DB path should not be empty").replace(Self::DB_NAME, "");
-            let db_path = Path::new(&path_str).join(format!("bmp_{}.db3", key.to_lower_hex_string()));
-
-            let mut db = Connection::open(db_path)?;
-            let imported_wallet_opt = Wallet::load()
-                .check_network(self.wallet.network())
-                .extract_keys()
-                .load_wallet(&mut db)?;
-            let wallet = if let Some(w) = imported_wallet_opt { w } else {
-                let descriptor = format!("tr({})", key.to_lower_hex_string());
-                Wallet::create_single(descriptor)
-                    .network(self.wallet.network())
-                    .create_wallet(&mut db)?
-            };
-            let LightClient {
-                requester,
-                info_subscriber: _,
-                warning_subscriber: _,
-                update_subscriber,
-                node,
-            } = Builder::new(self.network())
-                .add_peers(peers.clone())
-                .build_with_wallet(&wallet, scan_type)?;
-            tokio::task::spawn(async move { node.run().await });
-            entries.push(KeyEntry { db, wallet, update_subscriber, requester });
-        }
-
-        // Collect updates from all nodes while they are all running, then shut down together.
-        let mut final_imported_balance = Balance::default();
-        for entry in &mut entries {
-            let updates = entry.update_subscriber.update().await?;
-            entry.wallet.apply_update(updates)?;
-            entry.wallet.persist(&mut entry.db)?;
-            final_imported_balance = final_imported_balance + entry.wallet.balance();
-        }
-
-        for entry in entries {
-            let _ = entry.requester.shutdown();
-        }
-
-        self.imported_balance = final_imported_balance;
-
-        Ok(())
-    }
-
-    fn sync_all(&mut self, data_source: &impl ChainDataSource) -> anyhow::Result<bool> {
-        // 1. Sync the main wallet
-        data_source.sync(&mut self.wallet)?;
-
-        let mut final_imported_balance = Balance::default();
-
-        // 2. Sync the imported keys
-        // @TODO: we can spawn threads later on to speed up the process
-
-        for key in self.imported_keys.clone() {
-            let pbk = key.base_point_mul();
-            let pubkey = pbk.serialize_xonly().to_lower_hex_string();
-            let path_str = self.db.path().expect("DB path should not be empty").replace(Self::DB_NAME, "");
-            let db_path = Path::new(&path_str).join(format!("bmp_{pubkey}.db3"));
-
-            let mut db = Connection::open(db_path)?;
-            let imported_wallet_opt = Wallet::load()
-                .check_network(self.wallet.network())
-                .extract_keys()
-                .load_wallet(&mut db)?;
-
-            let mut imported_wallet = if let Some(wallet) = imported_wallet_opt { wallet } else {
-                let descriptor = format!("tr({pubkey})");
-
-                Wallet::create_single(descriptor)
-                    .network(self.wallet.network())
-                    .create_wallet(&mut db)?
-            };
-
-            data_source.sync(&mut imported_wallet)?;
-
-            final_imported_balance = final_imported_balance + imported_wallet.balance();
-
-            // For having accurate Wallet::calculate_fee and Wallet::calculate_fee_rate
-            for utxo in imported_wallet.list_unspent() {
-                self.insert_txout(utxo.outpoint, utxo.txout);
-            }
-
-            imported_wallet.persist(&mut db)?;
-        }
-
-        self.imported_balance = final_imported_balance;
-
-        self.persist()
     }
 
     // For already created wallets this will load stored data
@@ -795,6 +677,7 @@ mod tests {
     use std::str::FromStr as _;
 
     use bdk_kyoto::FeeRate;
+    use bdk_kyoto::bip157::tokio;
     use bdk_wallet::bitcoin::hashes::Hash as _;
     use bdk_wallet::bitcoin::{Address, AddressType, Amount, BlockHash, Network, Weight, psbt};
     use bdk_wallet::chain::{self, BlockId};
@@ -913,8 +796,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_sync() -> anyhow::Result<()> {
+    #[tokio::test]
+    async fn test_sync() -> anyhow::Result<()> {
         let dir = get_dir();
         let mut bmp_wallet = BMPWallet::new(dir.path(), "", Network::Regtest)?;
         let client = MockedBDKElectrum {};
@@ -922,7 +805,7 @@ mod tests {
         tracing::info!("Wallet balance before syncing {}", bmp_wallet.balance());
         assert_eq!(bmp_wallet.balance(), Amount::from_int_btc(0));
 
-        let _ = bmp_wallet.sync_all(&client);
+        bmp_wallet.sync_all(&client).await?;
 
         assert_eq!(bmp_wallet.balance(), Amount::from_int_btc(1));
 
@@ -932,8 +815,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_sync_with_imported_keys() -> anyhow::Result<()> {
+    #[tokio::test]
+    async fn test_sync_with_imported_keys() -> anyhow::Result<()> {
         let pk1 = new_private_key();
         let pk2 = new_private_key();
         let dir = get_dir();
@@ -949,7 +832,7 @@ mod tests {
         tracing::info!("Wallet balance before syncing {}", bmp_wallet.balance());
         assert_eq!(bmp_wallet.balance(), Amount::from_int_btc(0));
 
-        let _ = bmp_wallet.sync_all(&client);
+        bmp_wallet.sync_all(&client).await?;
 
         assert_eq!(bmp_wallet.balance(), Amount::from_int_btc(3));
 
@@ -957,8 +840,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn sign_inputs_main_wallet_only() -> anyhow::Result<()> {
+    #[tokio::test]
+    async fn sign_inputs_main_wallet_only() -> anyhow::Result<()> {
         let client = MockedBDKElectrum {};
         let dir = get_dir();
         let mut bmp_wallet = BMPWallet::new(dir.path(), "", Network::Regtest)?;
@@ -966,7 +849,7 @@ mod tests {
         tracing::info!("Wallet balance before syncing {}", bmp_wallet.balance());
         assert_eq!(bmp_wallet.balance(), Amount::from_int_btc(0));
 
-        let _ = bmp_wallet.sync_all(&client);
+        bmp_wallet.sync_all(&client).await?;
 
         assert_eq!(bmp_wallet.balance(), Amount::from_int_btc(1));
 
@@ -991,8 +874,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn sign_inputs_main_and_imported_keys() -> anyhow::Result<()> {
+    #[tokio::test]
+    async fn sign_inputs_main_and_imported_keys() -> anyhow::Result<()> {
         let client = MockedBDKElectrum {};
         let dir = get_dir();
         let mut bmp_wallet = BMPWallet::new(dir.path(), "", Network::Regtest)?;
@@ -1005,7 +888,7 @@ mod tests {
         tracing::info!("Wallet balance before syncing {}", bmp_wallet.balance());
         assert_eq!(bmp_wallet.balance(), Amount::from_int_btc(0));
 
-        let _ = bmp_wallet.sync_all(&client);
+        bmp_wallet.sync_all(&client).await?;
 
         assert_eq!(bmp_wallet.balance(), Amount::from_int_btc(3));
 
@@ -1061,8 +944,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_selection_with_main_and_imported() -> anyhow::Result<()> {
+    #[tokio::test]
+    async fn test_selection_with_main_and_imported() -> anyhow::Result<()> {
         let client = MockedBDKElectrum {};
         let dir = get_dir();
         let mut bmp_wallet = BMPWallet::new(dir.path(), "", Network::Regtest)?;
@@ -1080,7 +963,7 @@ mod tests {
         bmp_wallet.import_private_key(Scalar::from_slice(&pk1).unwrap());
         bmp_wallet.import_private_key(Scalar::from_slice(&pk2).unwrap());
 
-        bmp_wallet.sync_all(&client)?;
+        bmp_wallet.sync_all(&client).await?;
 
         let to_address = "tb1pyfv094rr0vk28lf8v9yx3veaacdzg26ztqk4ga84zucqqhafnn5q9my9rz";
         let to_address = to_address.parse::<Address<_>>()?.assume_checked();
@@ -1140,8 +1023,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn drain_wallet() -> anyhow::Result<()> {
+    #[tokio::test]
+    async fn drain_wallet() -> anyhow::Result<()> {
         let pk1 = new_private_key();
         let pk2 = new_private_key();
         let dir = get_dir();
@@ -1157,7 +1040,7 @@ mod tests {
         tracing::info!("Wallet balance before syncing {}", bmp_wallet.balance());
         assert_eq!(bmp_wallet.balance(), Amount::from_int_btc(0));
 
-        let _ = bmp_wallet.sync_all(&client);
+        bmp_wallet.sync_all(&client).await?;
 
         assert_eq!(bmp_wallet.balance(), Amount::from_int_btc(3));
         assert_eq!(
@@ -1175,8 +1058,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_wallet_with_path_creation() -> anyhow::Result<()> {
+    #[tokio::test]
+    async fn test_wallet_with_path_creation() -> anyhow::Result<()> {
         let dir_one = get_dir();
         let dir_two = get_dir();
 
@@ -1190,7 +1073,7 @@ mod tests {
 
         tracing::debug!("Wallet one balance before syncing {}", w1.balance());
         assert_eq!(w1.balance(), Amount::from_int_btc(0));
-        let _ = w1.sync_all(&client);
+        w1.sync_all(&client).await?;
 
         assert_eq!(w1.balance(), Amount::from_int_btc(1));
         assert_eq!(w2.balance(), Amount::ZERO);

--- a/wallet/src/chain_data_source.rs
+++ b/wallet/src/chain_data_source.rs
@@ -51,9 +51,15 @@ impl ChainDataSource for CBFScanner {
             .await?;
 
         for (descriptor, update) in updates {
-            let idx = *descriptors_map.get(&descriptor).unwrap();
-            let w = &mut **wallets.get_mut(idx).unwrap();
-            w.apply_update(update)?;
+            let idx = descriptors_map
+                .get(&descriptor)
+                .copied()
+                .ok_or_else(|| anyhow::anyhow!("unknown descriptor in update: {descriptor:?}"))?;
+            let wallet_to_update = wallets
+                .get_mut(idx)
+                .ok_or_else(|| anyhow::anyhow!("missing wallet for descriptor index {idx}"))?;
+            let wallet_to_update = &mut **wallet_to_update;
+            wallet_to_update.apply_update(update)?;
         }
         Ok(())
     }

--- a/wallet/src/chain_data_source.rs
+++ b/wallet/src/chain_data_source.rs
@@ -1,36 +1,59 @@
-use bdk_wallet::PersistedWallet;
-use chain::ChainScanner as _;
+use std::collections::BTreeMap;
+
+use bdk_kyoto::ScanType;
+use bdk_kyoto::bip157::Network;
+use bdk_wallet::chain::DescriptorExt;
+use bdk_wallet::{KeychainKind, PersistedWallet};
+use chain::CBFScanner;
 
 use crate::bmp_wallet::BMPWalletPersister;
 
+#[trait_variant::make(Send)]
 pub trait ChainDataSource {
     const RECOVERY_HEIGHT: usize;
     const BATCH_SIZE: usize;
     const STOP_GAP: usize;
 
-    fn sync(&self, _persister: &mut PersistedWallet<impl BMPWalletPersister>)
-    -> anyhow::Result<()>;
+    async fn sync(
+        &self,
+        _persister: Vec<&mut PersistedWallet<impl BMPWalletPersister>>,
+    ) -> anyhow::Result<()>;
 }
 
-/// `ChainDataSource` implementation for the Electrum-backed [`testenv::Testchain`] handle.
-///
-/// `Testchain` lives in the `testenv` crate alongside `TestEnv`; this impl ties it into the
-/// wallet's sync routine. It mirrors the values previously used by the live Electrum-backed
-/// implementation.
-impl ChainDataSource for testenv::Testchain {
+impl ChainDataSource for CBFScanner {
     const RECOVERY_HEIGHT: usize = 190_000;
     const BATCH_SIZE: usize = 16;
     const STOP_GAP: usize = 10;
 
-    fn sync(&self, persister: &mut PersistedWallet<impl BMPWalletPersister>) -> anyhow::Result<()> {
-        let tx_nodes = persister.tx_graph().full_txs().map(|tx_node| tx_node.tx);
-        self.populate_tx_cache(tx_nodes);
-        let request = persister.start_full_scan();
+    async fn sync(
+        &self,
+        mut wallets: Vec<&mut PersistedWallet<impl BMPWalletPersister>>,
+    ) -> anyhow::Result<()> {
+        let network = Network::Bitcoin;
+        let wallet_iter = wallets
+            .iter()
+            .map(|w| {
+                let wallet_deref = &***w;
+                (wallet_deref, ScanType::Sync)
+            })
+            .collect::<Vec<_>>();
 
-        let updates = self.full_scan(request, Self::STOP_GAP, Self::BATCH_SIZE, false)?;
+        let descriptors_map = wallets
+            .iter()
+            .enumerate()
+            .map(|(idx, w)| {
+                let key = w.public_descriptor(KeychainKind::External).descriptor_id();
+                (key, idx)
+            })
+            .collect::<BTreeMap<_, _>>();
 
-        persister.apply_update(updates)?;
+        let updates = self.sync_cbf(network, wallet_iter).await?;
 
+        for (descriptor, update) in updates {
+            let idx = *descriptors_map.get(&descriptor).unwrap();
+            let w = &mut *wallets.get_mut(idx).unwrap();
+            w.apply_update(update)?;
+        }
         Ok(())
     }
 }

--- a/wallet/src/chain_data_source.rs
+++ b/wallet/src/chain_data_source.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use bdk_kyoto::ScanType;
-use bdk_wallet::chain::DescriptorExt;
+use bdk_wallet::chain::DescriptorExt as _;
 use bdk_wallet::{KeychainKind, PersistedWallet};
 use chain::CBFScanner;
 
@@ -52,7 +52,7 @@ impl ChainDataSource for CBFScanner {
 
         for (descriptor, update) in updates {
             let idx = *descriptors_map.get(&descriptor).unwrap();
-            let w = &mut *wallets.get_mut(idx).unwrap();
+            let w = &mut **wallets.get_mut(idx).unwrap();
             w.apply_update(update)?;
         }
         Ok(())

--- a/wallet/src/chain_data_source.rs
+++ b/wallet/src/chain_data_source.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 
 use bdk_kyoto::ScanType;
-use bdk_kyoto::bip157::Network;
 use bdk_wallet::chain::DescriptorExt;
 use bdk_wallet::{KeychainKind, PersistedWallet};
 use chain::CBFScanner;
@@ -29,7 +28,7 @@ impl ChainDataSource for CBFScanner {
         &self,
         mut wallets: Vec<&mut PersistedWallet<impl BMPWalletPersister>>,
     ) -> anyhow::Result<()> {
-        let network = Network::Bitcoin;
+        let network = wallets[0].network();
         let wallet_iter = wallets
             .iter()
             .map(|w| {
@@ -47,7 +46,9 @@ impl ChainDataSource for CBFScanner {
             })
             .collect::<BTreeMap<_, _>>();
 
-        let updates = self.sync_cbf(network, wallet_iter).await?;
+        let updates = self
+            .sync_cbf(network, self.peers.clone(), wallet_iter)
+            .await?;
 
         for (descriptor, update) in updates {
             let idx = *descriptors_map.get(&descriptor).unwrap();

--- a/wallet/src/protocol_wallet_api.rs
+++ b/wallet/src/protocol_wallet_api.rs
@@ -5,11 +5,11 @@ use std::time::Duration;
 
 use bdk_electrum::BdkElectrumClient;
 use bdk_electrum::bdk_core::bitcoin::bip32::Xpriv;
-use bdk_electrum::bdk_core::bitcoin::{
-    Address, Amount, FeeRate, Network, OutPoint, Psbt, ScriptBuf, XOnlyPublicKey,
-};
 use bdk_electrum::electrum_client::Client;
-use bdk_wallet::bitcoin::{absolute, secp256k1};
+use bdk_wallet::bitcoin::{
+    Address, Amount, FeeRate, Network, OutPoint, Psbt, ScriptBuf, XOnlyPublicKey, absolute,
+    secp256k1,
+};
 use bdk_wallet::coin_selection::CoinSelectionAlgorithm;
 use bdk_wallet::descriptor::{Descriptor, ExtendedDescriptor};
 use bdk_wallet::miniscript::ToPublicKey as _;

--- a/wallet/src/protocol_wallet_api.rs
+++ b/wallet/src/protocol_wallet_api.rs
@@ -148,7 +148,7 @@ impl MemWallet {
         client: BdkElectrumClient<Client>,
     ) -> anyhow::Result<Self>
     where
-        R: chain::ChainApi,
+        R: chain::ChainFunding,
     {
         const MAX_RETRIES: u32 = 20;
         const RETRY_DELAY_MS: u64 = 500;

--- a/wallet/src/protocol_wallet_api.rs
+++ b/wallet/src/protocol_wallet_api.rs
@@ -1,12 +1,15 @@
 use std::io::Write as _;
 use std::mem;
 use std::sync::LazyLock;
+use std::time::Duration;
 
 use bdk_electrum::BdkElectrumClient;
 use bdk_electrum::bdk_core::bitcoin::bip32::Xpriv;
-use bdk_electrum::bdk_core::bitcoin::{XOnlyPublicKey, absolute, secp256k1};
+use bdk_electrum::bdk_core::bitcoin::{
+    Address, Amount, FeeRate, Network, OutPoint, Psbt, ScriptBuf, XOnlyPublicKey,
+};
 use bdk_electrum::electrum_client::Client;
-use bdk_wallet::bitcoin::{Address, Amount, FeeRate, Network, OutPoint, Psbt, ScriptBuf};
+use bdk_wallet::bitcoin::{absolute, secp256k1};
 use bdk_wallet::coin_selection::CoinSelectionAlgorithm;
 use bdk_wallet::descriptor::{Descriptor, ExtendedDescriptor};
 use bdk_wallet::miniscript::ToPublicKey as _;
@@ -92,11 +95,11 @@ impl MemWallet {
         );
 
         let (descriptor, external_map, _) = Bip86(xprv, KeychainKind::External)
-            .build(network)
+            .build(network.into())
             .expect("Failed to build external descriptor");
 
         let (change_descriptor, internal_map, _) = Bip86(xprv, KeychainKind::Internal)
-            .build(network)
+            .build(network.into())
             .expect("Failed to build internal descriptor");
 
         let wallet = Wallet::create(descriptor, change_descriptor)
@@ -140,17 +143,32 @@ impl MemWallet {
         self.wallet.next_unused_address(KeychainKind::External)
     }
 
-    pub fn funded_wallet(env: &mut testenv::TestEnv) -> Self {
-        let client = BdkElectrumClient::new(Client::new(&env.electrum_url()).unwrap());
-        let mut wallet = Self::new(client).unwrap();
-        let address = wallet.next_unused_address();
-        let txid = env
-            .fund_address(&address, Amount::from_btc(10f64).unwrap())
-            .unwrap();
-        env.mine_block().unwrap();
-        env.wait_for_tx(txid).unwrap();
-        wallet.sync().unwrap();
-        wallet
+    pub fn funded_wallet_from_rpc<R>(
+        rpc: &R,
+        client: BdkElectrumClient<Client>,
+    ) -> anyhow::Result<Self>
+    where
+        R: chain::ChainApi,
+    {
+        const MAX_RETRIES: u32 = 20;
+        const RETRY_DELAY_MS: u64 = 500;
+
+        let mut wallet = Self::new(client)?;
+        let address = wallet.reveal_next_address();
+        rpc.send_to_address(&address, Amount::from_btc(10f64).unwrap())?;
+        rpc.generate_to_address(1, &address)?;
+
+        for attempt in 0..MAX_RETRIES {
+            wallet.sync()?;
+            if wallet.balance() > Amount::from_sat(0) {
+                tracing::info!("Wallet funded after {} retries", attempt);
+                return Ok(wallet);
+            }
+            if attempt < MAX_RETRIES - 1 {
+                std::thread::sleep(Duration::from_millis(RETRY_DELAY_MS));
+            }
+        }
+        anyhow::bail!("Wallet failed to sync funded balance after {MAX_RETRIES} attempts")
     }
 }
 

--- a/wallet/src/test_utils.rs
+++ b/wallet/src/test_utils.rs
@@ -26,31 +26,34 @@ impl ChainDataSource for MockedBDKElectrum {
     const BATCH_SIZE: usize = 10;
     const STOP_GAP: usize = 10;
 
-    fn sync(&self, persister: &mut PersistedWallet<impl BMPWalletPersister>) -> anyhow::Result<()> {
-        insert_checkpoint(
-            persister,
-            BlockId {
-                height: 42,
-                hash: BlockHash::all_zeros(),
-            },
-        );
-        insert_checkpoint(
-            persister,
-            BlockId {
-                height: 1_000,
-                hash: BlockHash::all_zeros(),
-            },
-        );
-        insert_checkpoint(
-            persister,
-            BlockId {
-                height: 2_000,
-                hash: BlockHash::all_zeros(),
-            },
-        );
-
-        receive_output_in_latest_block(persister, Amount::ONE_BTC);
-
+    async fn sync(
+        &self,
+        persister: Vec<&mut PersistedWallet<impl BMPWalletPersister>>,
+    ) -> anyhow::Result<()> {
+        for w in persister {
+            insert_checkpoint(
+                w,
+                BlockId {
+                    height: 42,
+                    hash: BlockHash::all_zeros(),
+                },
+            );
+            insert_checkpoint(
+                w,
+                BlockId {
+                    height: 1_000,
+                    hash: BlockHash::all_zeros(),
+                },
+            );
+            insert_checkpoint(
+                w,
+                BlockId {
+                    height: 2_000,
+                    hash: BlockHash::all_zeros(),
+                },
+            );
+            receive_output_in_latest_block(w, Amount::ONE_BTC);
+        }
         Ok(())
     }
 }

--- a/wallet/src/utils.rs
+++ b/wallet/src/utils.rs
@@ -3,8 +3,6 @@ use std::fs;
 use argon2::{Argon2, Block, Params};
 use base64::Engine as _;
 use base64::engine::general_purpose;
-use bdk_kyoto::bip157::tokio;
-use bdk_kyoto::{Info, Receiver, UnboundedReceiver, Warning};
 use zeroize::Zeroize as _;
 
 /// Derives a 256-bit key from a password and salt using Argon2.
@@ -27,22 +25,4 @@ pub fn get_salt(db_path: &str) -> anyhow::Result<Vec<u8>> {
     let salt_path = format!("{db_path}.salt");
     let salt_str = fs::read_to_string(&salt_path)?;
     Ok(general_purpose::STANDARD.decode(salt_str.as_bytes())?)
-}
-
-/// Implement a custom logger that prints log messages to the console.
-pub async fn trace_logs(mut info_rx: Receiver<Info>, mut warn_rx: UnboundedReceiver<Warning>) {
-    loop {
-        tokio::select! {
-            warn = warn_rx.recv() => {
-                if let Some(warn) = warn {
-                    tracing::warn!("{warn}");
-                }
-            }
-            infos = info_rx.recv() => {
-                if let Some(info) = infos {
-                    tracing::info!("{info}");
-                }
-            }
-        }
-    }
 }

--- a/wallet/tests/wallet_integration_test.rs
+++ b/wallet/tests/wallet_integration_test.rs
@@ -233,10 +233,10 @@ async fn test_cbf_main_wallet() -> anyhow::Result<()> {
     env.mine_blocks(4)?;
 
     let _scan_type = bdk_kyoto::ScanType::Sync;
-    let _peers = [TrustedPeer::from_socket_addr(
+    let peers = [TrustedPeer::from_socket_addr(
         env.p2p_socket_addr().unwrap(),
     )];
-    wallet.sync_all(&CBFScanner).await?;
+    wallet.sync_all(&CBFScanner::new(peers.to_vec())).await?;
     assert_eq!(wallet.balance(), Amount::from_sat(100_000));
     Ok(())
 }
@@ -261,11 +261,11 @@ async fn test_cbf_imported() -> anyhow::Result<()> {
     env.mine_blocks(4)?;
 
     let _ = bdk_kyoto::ScanType::Sync;
-    let _ = vec![TrustedPeer::from_socket_addr(
+    let peers = vec![TrustedPeer::from_socket_addr(
         env.p2p_socket_addr().unwrap(),
     )];
 
-    wallet.sync_all(&CBFScanner).await?;
+    wallet.sync_all(&CBFScanner::new(peers)).await?;
     assert_eq!(wallet.balance(), Amount::from_sat(30_000));
     Ok(())
 }
@@ -293,11 +293,11 @@ async fn test_cbf_imported_and_main() -> anyhow::Result<()> {
     env.mine_blocks(4)?;
 
     let _ = bdk_kyoto::ScanType::Sync;
-    let _ = vec![TrustedPeer::from_socket_addr(
+    let peers = vec![TrustedPeer::from_socket_addr(
         env.p2p_socket_addr().unwrap(),
     )];
 
-    wallet.sync_all(&CBFScanner).await?;
+    wallet.sync_all(&CBFScanner::new(peers)).await?;
 
     assert_eq!(wallet.balance(), Amount::from_sat(130_000));
 
@@ -317,12 +317,12 @@ async fn test_cbf_persistence() -> anyhow::Result<()> {
     env.fund_address(&addr, Amount::from_sat(230_000))?;
 
     let _scan_type = bdk_kyoto::ScanType::Sync;
-    let _peers = [TrustedPeer::from_socket_addr(
+    let peers = [TrustedPeer::from_socket_addr(
         env.p2p_socket_addr().unwrap(),
     )];
     env.mine_block()?;
 
-    let cbf = CBFScanner;
+    let cbf = CBFScanner::new(peers.to_vec());
     wallet.sync_all(&cbf).await?;
     assert_eq!(wallet.balance(), Amount::from_sat(230_000));
 

--- a/wallet/tests/wallet_integration_test.rs
+++ b/wallet/tests/wallet_integration_test.rs
@@ -61,7 +61,6 @@ async fn test_sync_with_imported_keys() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-
 async fn test_broadcast_transaction() -> anyhow::Result<()> {
     // This test broadcast a transaction created from main wallet balance only
     let mut env = TestEnv::new()?;
@@ -232,7 +231,6 @@ async fn test_cbf_main_wallet() -> anyhow::Result<()> {
 
     env.mine_blocks(4)?;
 
-    let _scan_type = bdk_kyoto::ScanType::Sync;
     let peers = [TrustedPeer::from_socket_addr(
         env.p2p_socket_addr().unwrap(),
     )];
@@ -259,8 +257,6 @@ async fn test_cbf_imported() -> anyhow::Result<()> {
     assert_eq!(wallet.balance(), Amount::from_sat(0));
 
     env.mine_blocks(4)?;
-
-    let _ = bdk_kyoto::ScanType::Sync;
     let peers = vec![TrustedPeer::from_socket_addr(
         env.p2p_socket_addr().unwrap(),
     )];
@@ -291,8 +287,6 @@ async fn test_cbf_imported_and_main() -> anyhow::Result<()> {
     assert_eq!(wallet.balance(), Amount::from_sat(0));
 
     env.mine_blocks(4)?;
-
-    let _ = bdk_kyoto::ScanType::Sync;
     let peers = vec![TrustedPeer::from_socket_addr(
         env.p2p_socket_addr().unwrap(),
     )];
@@ -316,7 +310,6 @@ async fn test_cbf_persistence() -> anyhow::Result<()> {
     let addr = wallet.next_unused_address(KeychainKind::External);
     env.fund_address(&addr, Amount::from_sat(230_000))?;
 
-    let _scan_type = bdk_kyoto::ScanType::Sync;
     let peers = [TrustedPeer::from_socket_addr(
         env.p2p_socket_addr().unwrap(),
     )];

--- a/wallet/tests/wallet_integration_test.rs
+++ b/wallet/tests/wallet_integration_test.rs
@@ -5,6 +5,7 @@ use bdk_kyoto::{FeeRate, TrustedPeer};
 use bdk_wallet::bitcoin::{Address, Amount, Network};
 use bdk_wallet::psbt::PsbtUtils as _;
 use bdk_wallet::{KeychainKind, SignOptions};
+use chain::CBFScanner;
 use rand::RngCore as _;
 use secp::Scalar;
 use testenv::TestEnv;
@@ -16,8 +17,8 @@ fn new_private_key() -> Scalar {
     Scalar::from_slice(&seed).unwrap()
 }
 
-#[test]
-fn init_test() -> anyhow::Result<()> {
+#[tokio::test]
+async fn init_test() -> anyhow::Result<()> {
     let mut env = TestEnv::new()?;
     let chain = env.new_testchain()?;
 
@@ -29,14 +30,14 @@ fn init_test() -> anyhow::Result<()> {
     env.fund_address(&receiving_addr, receive_amount)?;
     env.mine_block()?;
 
-    wallet.sync_all(&chain)?;
+    wallet.sync_all(&chain).await?;
 
     assert_eq!(wallet.balance(), receive_amount);
     Ok(())
 }
 
-#[test]
-fn test_sync_with_imported_keys() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_sync_with_imported_keys() -> anyhow::Result<()> {
     let mut env = TestEnv::new()?;
     let chain = env.new_testchain()?;
 
@@ -53,15 +54,15 @@ fn test_sync_with_imported_keys() -> anyhow::Result<()> {
     env.fund_from_prv_key(&prv_key, receive_amount)?;
     env.mine_block()?;
 
-    wallet.sync_all(&chain)?;
+    wallet.sync_all(&chain).await?;
     assert_eq!(wallet.balance(), receive_amount + receive_amount);
 
     Ok(())
 }
 
-#[test]
+#[tokio::test]
 
-fn test_broadcast_transaction() -> anyhow::Result<()> {
+async fn test_broadcast_transaction() -> anyhow::Result<()> {
     // This test broadcast a transaction created from main wallet balance only
     let mut env = TestEnv::new()?;
     let chain = env.new_testchain()?;
@@ -85,7 +86,7 @@ fn test_broadcast_transaction() -> anyhow::Result<()> {
     env.fund_address(&receiving_addr, receive_amount)?;
     env.mine_block()?;
 
-    wallet.sync_all(&chain)?;
+    wallet.sync_all(&chain).await?;
 
     let mut tx_builder = wallet.build_tx();
     let send_amount = Amount::from_sat(1_000);
@@ -101,7 +102,7 @@ fn test_broadcast_transaction() -> anyhow::Result<()> {
     env.mine_block()?;
 
     // Rescan the wallet to apply balance changes
-    wallet.sync_all(&chain)?;
+    wallet.sync_all(&chain).await?;
 
     let new_balance = receive_amount - send_amount - fee;
     assert_eq!(wallet.balance(), new_balance);
@@ -113,8 +114,8 @@ fn test_broadcast_transaction() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_broadcast_transaction_two() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_broadcast_transaction_two() -> anyhow::Result<()> {
     // This test broadcast a transaction created from imported wallets only
     let mut env = TestEnv::new()?;
     let chain = env.new_testchain()?;
@@ -133,7 +134,7 @@ fn test_broadcast_transaction_two() -> anyhow::Result<()> {
     env.fund_from_prv_key(&prv_key, receive_amount)?;
     env.mine_block()?;
 
-    wallet.sync_all(&chain)?;
+    wallet.sync_all(&chain).await?;
 
     let mut tx_builder = wallet.build_tx();
     let send_amount = Amount::from_sat(1_000);
@@ -149,7 +150,7 @@ fn test_broadcast_transaction_two() -> anyhow::Result<()> {
     env.mine_block()?;
 
     // Rescan the wallet to apply balance changes
-    wallet.sync_all(&chain)?;
+    wallet.sync_all(&chain).await?;
 
     let new_balance = receive_amount - send_amount - fee;
     assert_eq!(wallet.balance(), new_balance);
@@ -161,8 +162,8 @@ fn test_broadcast_transaction_two() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_broadcast_transaction_three() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_broadcast_transaction_three() -> anyhow::Result<()> {
     // This test will attempt send a transaction created from both main wallet and imported keys
     // balance
     let mut env = TestEnv::new()?;
@@ -186,7 +187,7 @@ fn test_broadcast_transaction_three() -> anyhow::Result<()> {
 
     env.mine_block()?;
 
-    wallet.sync_all(&chain)?;
+    wallet.sync_all(&chain).await?;
 
     let mut tx_builder = wallet.build_tx();
     let send_amount = Amount::from_sat(100_000);
@@ -203,7 +204,7 @@ fn test_broadcast_transaction_three() -> anyhow::Result<()> {
     env.mine_block()?;
 
     // Rescan the wallet to apply balance changes
-    wallet.sync_all(&chain)?;
+    wallet.sync_all(&chain).await?;
 
     let new_balance = (receive_amount + receive_amount) - send_amount - fee;
     assert_eq!(wallet.balance(), new_balance);
@@ -213,7 +214,7 @@ fn test_broadcast_transaction_three() -> anyhow::Result<()> {
 
     env.fund_address(&main_wallet_addr, Amount::from_sat(10_000))?;
     env.mine_block()?;
-    enc_wallet.sync_all(&chain)?;
+    enc_wallet.sync_all(&chain).await?;
     assert_eq!(enc_wallet.balance(), new_balance + Amount::from_sat(10_000));
 
     Ok(())
@@ -231,11 +232,11 @@ async fn test_cbf_main_wallet() -> anyhow::Result<()> {
 
     env.mine_blocks(4)?;
 
-    let scan_type = bdk_kyoto::ScanType::Sync;
-    let peers = vec![TrustedPeer::from_socket_addr(
+    let _scan_type = bdk_kyoto::ScanType::Sync;
+    let _peers = [TrustedPeer::from_socket_addr(
         env.p2p_socket_addr().unwrap(),
     )];
-    wallet.sync_cbf(scan_type, peers).await?;
+    wallet.sync_all(&CBFScanner).await?;
     assert_eq!(wallet.balance(), Amount::from_sat(100_000));
     Ok(())
 }
@@ -259,11 +260,12 @@ async fn test_cbf_imported() -> anyhow::Result<()> {
 
     env.mine_blocks(4)?;
 
-    let scan_type = bdk_kyoto::ScanType::Sync;
-    let peers = vec![TrustedPeer::from_socket_addr(
+    let _ = bdk_kyoto::ScanType::Sync;
+    let _ = vec![TrustedPeer::from_socket_addr(
         env.p2p_socket_addr().unwrap(),
     )];
-    wallet.sync_cbf_imported(scan_type, peers).await?;
+
+    wallet.sync_all(&CBFScanner).await?;
     assert_eq!(wallet.balance(), Amount::from_sat(30_000));
     Ok(())
 }
@@ -290,13 +292,12 @@ async fn test_cbf_imported_and_main() -> anyhow::Result<()> {
 
     env.mine_blocks(4)?;
 
-    let scan_type = bdk_kyoto::ScanType::Sync;
-    let peers = vec![TrustedPeer::from_socket_addr(
+    let _ = bdk_kyoto::ScanType::Sync;
+    let _ = vec![TrustedPeer::from_socket_addr(
         env.p2p_socket_addr().unwrap(),
     )];
 
-    wallet.sync_cbf_imported(scan_type, peers.clone()).await?;
-    wallet.sync_cbf(scan_type, peers).await?;
+    wallet.sync_all(&CBFScanner).await?;
 
     assert_eq!(wallet.balance(), Amount::from_sat(130_000));
 
@@ -315,12 +316,14 @@ async fn test_cbf_persistence() -> anyhow::Result<()> {
     let addr = wallet.next_unused_address(KeychainKind::External);
     env.fund_address(&addr, Amount::from_sat(230_000))?;
 
-    let scan_type = bdk_kyoto::ScanType::Sync;
-    let peers = vec![TrustedPeer::from_socket_addr(
+    let _scan_type = bdk_kyoto::ScanType::Sync;
+    let _peers = [TrustedPeer::from_socket_addr(
         env.p2p_socket_addr().unwrap(),
     )];
     env.mine_block()?;
-    wallet.sync_cbf(scan_type, peers.clone()).await?;
+
+    let cbf = CBFScanner;
+    wallet.sync_all(&cbf).await?;
     assert_eq!(wallet.balance(), Amount::from_sat(230_000));
 
     // Reload the wallet from persisted state
@@ -329,7 +332,7 @@ async fn test_cbf_persistence() -> anyhow::Result<()> {
 
     env.fund_address(&addr, Amount::from_sat(70_000))?;
     env.mine_block()?;
-    loaded_wallet.sync_cbf(scan_type, peers.clone()).await?;
+    loaded_wallet.sync_all(&cbf).await?;
     assert_eq!(loaded_wallet.balance(), Amount::from_sat(300_000));
 
     // Create a transaction and broadcast it to the connected peer
@@ -347,7 +350,7 @@ async fn test_cbf_persistence() -> anyhow::Result<()> {
     env.broadcast(&psbt.extract_tx()?)?;
     env.mine_block()?;
 
-    loaded_wallet.sync_cbf(scan_type, peers).await?;
+    loaded_wallet.sync_all(&cbf).await?;
     assert_eq!(loaded_wallet.balance(), Amount::from_sat(230_000) - fee);
 
     Ok(())
@@ -378,7 +381,7 @@ async fn test_drain_wallet_with_main_balance() -> anyhow::Result<()> {
     }
 
     env.mine_block()?;
-    wallet.sync_all(&chain)?;
+    wallet.sync_all(&chain).await?;
 
     // Doing *2 because we have two imported keys with the same amount received 10_000
     let current_balance = amount_to_send_main_wallet + amount_to_send_imported * 2;
@@ -395,7 +398,7 @@ async fn test_drain_wallet_with_main_balance() -> anyhow::Result<()> {
     env.broadcast(&tx)?;
     env.mine_block()?;
 
-    wallet.sync_all(&chain)?;
+    wallet.sync_all(&chain).await?;
 
     let main_wallet_balance = drained_amount + amount_to_send_main_wallet;
 


### PR DESCRIPTION

This PR also introduces several changes
- bump bdk_wallet to 3
- bump bdk_kyoto to 0.16
- make the production code completely free from testenv