### PR TITLE
Remove `TradeWallet` trait and move `MockTradeWallet` to its own module

### DIFF
--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -1,6 +1,7 @@
+pub mod mocks;
 pub mod multisig;
 pub mod protocol_musig_adaptor;
-pub mod psbt;
+mod psbt;
 pub mod receiver;
 pub mod script_paths;
 mod swap;

--- a/protocol/src/mocks.rs
+++ b/protocol/src/mocks.rs
@@ -1,0 +1,222 @@
+use std::collections::BTreeMap;
+
+use bdk_wallet::bitcoin::taproot::Signature;
+use bdk_wallet::bitcoin::transaction::Version;
+use bdk_wallet::bitcoin::{
+    Address, Amount, FeeRate, Network, OutPoint, Psbt, ScriptBuf, Sequence, TapSighashType,
+    Transaction, TxIn, TxOut, VarInt, Weight, Witness, XOnlyPublicKey, absolute, psbt,
+};
+use musig2::secp::Scalar;
+use wallet::protocol_wallet_api::{ProtocolWalletApi, WalletErrorKind};
+
+use crate::mocks::WalletErrorKind::Other;
+use crate::psbt::Redact as _;
+use crate::transaction::{TransactionErrorKind, TxOutput};
+
+struct MockTradeWallet<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> {
+    funding_coins: Cs,
+    new_addresses: As,
+    signature_map: BTreeMap<OutPoint, Signature>,
+    internal_key: Option<XOnlyPublicKey>,
+    script_sigs: BTreeMap<XOnlyPublicKey, Vec<Signature>>,
+}
+
+impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> ProtocolWalletApi for MockTradeWallet<Cs, As> {
+    fn network(&self) -> Network { Network::Regtest }
+
+    fn new_address(&mut self) -> Result<Address, WalletErrorKind> {
+        self.new_addresses.next().ok_or_else(|| Other(TransactionErrorKind::MissingAddress.into()))
+    }
+
+    fn new_internal_key(&mut self) -> Result<XOnlyPublicKey, WalletErrorKind> {
+        self.internal_key.take().ok_or_else(|| Other(TransactionErrorKind::MissingAddress.into()))
+    }
+
+    fn create_psbt(
+        &mut self,
+        mut recipients: Vec<(ScriptBuf, Amount)>,
+        fee_rate: FeeRate,
+    ) -> Result<Psbt, WalletErrorKind> {
+        let fee_cost_msat = |weight: Weight|
+            fee_rate.to_sat_per_kwu().checked_mul(weight.to_wu())
+                .ok_or(Other(TransactionErrorKind::Overflow.into()));
+
+        // Provisionally add a change recipient of zero value. We should never normally use
+        // `new_address()` for change outputs, but this is just a mock.
+        recipients.push((self.new_address()?.script_pubkey(), Amount::ZERO));
+
+        let base_weight = Weight::from_wu_usize(38 + 4 * VarInt::from(recipients.len()).size());
+        let mut output = Vec::with_capacity(recipients.len());
+        let mut cost_msat = fee_cost_msat(base_weight)?;
+
+        for (script_pubkey, value) in recipients {
+            let tx_out = TxOut { value, script_pubkey };
+            cost_msat = (|| cost_msat
+                .checked_add(value.to_sat().checked_mul(1000)?)?
+                .checked_add(fee_cost_msat(tx_out.weight()).ok()?))()
+                .ok_or(Other(TransactionErrorKind::Overflow.into()))?;
+            output.push(tx_out);
+        }
+
+        let mut input = Vec::new();
+        let mut inputs = Vec::new();
+        let mut funds = Amount::ZERO;
+
+        while funds < Amount::from_sat(cost_msat.div_ceil(1000)) {
+            let new_coin = self.funding_coins.next()
+                .ok_or(Other(TransactionErrorKind::MissingTxOutput.into()))?;
+            let new_coin_weight = new_coin.estimated_input_weight()
+                .ok_or(Other(TransactionErrorKind::InvalidPsbt.into()))?;
+            funds = funds.checked_add(new_coin.prevout.value)
+                .ok_or(Other(TransactionErrorKind::Overflow.into()))?;
+            cost_msat = cost_msat.checked_add(fee_cost_msat(new_coin_weight)?)
+                .ok_or(Other(TransactionErrorKind::Overflow.into()))?;
+            input.push(TxIn {
+                previous_output: new_coin.outpoint,
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                ..TxIn::default()
+            });
+            inputs.push(psbt::Input {
+                witness_utxo: Some(new_coin.prevout),
+                ..psbt::Input::default()
+            });
+        }
+
+        let change_output = output.last_mut().expect("tx has a provisional change output");
+        change_output.value = funds - Amount::from_sat(cost_msat.div_ceil(1000));
+        if change_output.value < change_output.script_pubkey.minimal_non_dust() {
+            output.pop();
+        }
+
+        let unsigned_tx = Transaction {
+            version: Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input,
+            output,
+        };
+        Ok(Psbt { inputs, ..Psbt::from_unsigned_tx(unsigned_tx).expect("tx is unsigned by construction") })
+    }
+
+    fn sign_selected_inputs(
+        &mut self,
+        psbt: &mut Psbt,
+        is_selected: &dyn Fn(&OutPoint) -> bool,
+    ) -> Result<(), WalletErrorKind> {
+        let mut script_sigs = self.script_sigs.clone();
+
+        for (input, TxIn { previous_output, .. })
+        in psbt.inputs.iter_mut().zip(&psbt.unsigned_tx.input)
+        {
+            if is_selected(previous_output) {
+                for (key, (leaf_hashes, _)) in &input.tap_key_origins {
+                    if let Some(sig) = script_sigs.get_mut(key).and_then(Vec::pop) {
+                        for leaf_hash in leaf_hashes {
+                            input.tap_script_sigs.insert((*key, *leaf_hash), sig);
+                        }
+                    }
+                }
+                if let Some(signature) = self.signature_map.get(previous_output) {
+                    // Mock keyspend:
+                    input.final_script_witness = Some(Witness::p2tr_key_spend(signature));
+                    input.redact_sensitive_fields();
+                } else if input.tap_key_origins.len() == input.tap_script_sigs.len() + 1 {
+                    // Mock script spend (assumes only one path):
+                    if let Some((control_block, (script, _))) = input.tap_scripts.first_key_value()
+                    {
+                        let mut wit = Witness::new();
+                        // For the purpose of the mock, assume that (pubkey, leaf-hash) -> signature
+                        // mappings occur in the opposite order that the signatures need to be added
+                        // to the witness. This won't be true in general.
+                        for sig in input.tap_script_sigs.values().rev() {
+                            wit.push(sig.serialize());
+                        }
+                        wit.push(script.as_bytes());
+                        wit.push(control_block.serialize());
+                        input.final_script_witness = Some(wit);
+                        input.redact_sensitive_fields();
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn import_private_key(&mut self, _pk: Scalar) {
+        unimplemented!("MockTradeWallet does not support importing private keys")
+    }
+}
+
+//noinspection SpellCheckingInspection
+pub fn mock_buyer_trade_wallet() -> impl ProtocolWalletApi {
+    let funding_coins = [
+        "658654575bbbeb46e965bd9eb37fd3be550a7e0fa2d64bc5f218763155602300:0",
+    ].map(TxOutput::mock_1_btc_coin).into_iter();
+    let signature_map = signature_map(funding_coins.as_slice(), &[
+        "f631ae99b4743315b237af9c48ae1f9bb87b6c5404e84d8e3907269218d1bba5\
+         4c397158aa233fd3f2227f4dc46922ef62eb8cc39a06b7a339b33e2401d512c1",
+    ]);
+    let new_addresses = [
+        "bcrt1pgsj9aw0wvs5h6zj780djnu267v6jazmfekwm4g4q4s6ax3w3t0lseqqnjc",
+        "bcrt1pkar3gerekw8f9gef9vn9xz0qypytgacp9wa5saelpksdgct33qdqan7c89",
+        "bcrt1pv537m7m6w0gdrcdn3mqqdpgrk3j400yrdrjwf5c9whyl2f8f4p6q9dn3l9",
+        "bcrt1pzvynlely05x82u40cts3znctmvyskue74xa5zwy0t5ueuv92726szpgpaa",
+    ].map(|a| a.parse::<Address<_>>()
+        .expect("hardcoded addresses should be valid").assume_checked()).into_iter();
+    let internal_key =
+        "51494dc22e24a32fe9dcfbd7e85faf345fa1df296fb49d156e859ef345201295".parse().ok();
+    let script_sigs = script_sigs(internal_key.as_slice(), &[
+        "5564448d3c5f024eaf2c65024a0c6e7a9066eb0390f8ffaeee2feacde310fabf\
+         87f3a8d8ad7fb125d7a6f68a282cfab8cd3178262a1fd0c2d06a598c8c454af8",
+        "652d0abaa3b4f8c7dd85ac9d523d44f768c8e1541aded79165c3cdfb3ba35d62\
+         eef114e89becb490a80cfdab946d2d91748ccea501ceb4f08655dcc2868c0463",
+    ]);
+
+    MockTradeWallet { funding_coins, new_addresses, signature_map, internal_key, script_sigs }
+}
+
+//noinspection SpellCheckingInspection
+pub fn mock_seller_trade_wallet() -> impl ProtocolWalletApi {
+    let funding_coins = [
+        "4a5ecc72ec8db78f11c6785f560a13f6f32eac66d160a8157d30956695ccf523:0",
+        "373b3ca0b9135e9649672772d4659bb5597d06b4694f1fbdbece285823fde0a3:1",
+    ].map(TxOutput::mock_1_btc_coin).into_iter();
+    let signature_map = signature_map(funding_coins.as_slice(), &[
+        "2376111ed79dac9ff6f2d85dfe57d142f6075f4df9381aeab87a941477425224\
+         7555f791ddf82354a3d73fa24955f6c5330ae44b2b238fa74be2eee9a46fcb72",
+        "637f4a624bfc46bdb52e01b923d157a97148210f1a2669716815d3249c615673\
+         17d543868698f30130e0aaf693ce265c544e3db5eda568bffb6ccd03d25a31df",
+    ]);
+    let new_addresses = [
+        "bcrt1p80xu5f0nqjarfnechsmlt488jf3tykx8cva9zeeczlsu4c7x557qr499gz",
+        "bcrt1pt5xd4aqe9whmvlz78mt39rvdlgpp6hujs5ggwan5285zjnsf73rq20k456",
+        "bcrt1pwxlp4v9v7v03nx0e7vunlc87d4936wnyqegw0fuahudypan64wysefpqzy",
+        "bcrt1pw4s5zvfm665fq9u6uwn9g7gwna658s939dvvf9wg63yede8kvyms5pmalx",
+        "bcrt1pe3kcs085e8qej9aqqx6qryv2qsfxzywy9xd8pryzwemv2dghdqgscylr69",
+    ].map(|a| a.parse::<Address<_>>()
+        .expect("hardcoded addresses should be valid").assume_checked()).into_iter();
+    let internal_key =
+        "fcba7ecf41bc7e1be4ee122d9d22e3333671eb0a3a87b5cdf099d59874e1940f".parse().ok();
+    let script_sigs = script_sigs(internal_key.as_slice(), &[
+        "87790f7eb3e98eb1b4dadc55ff5762275c4e3c02c6491abb26c8eabfada55b4b\
+         3f2627f627919d667be8f191a1b275b01549ab24e5eeda0019f83c658840500e",
+        "52fe2e44a4789a0f9bc406da144dcacca2621d2c1286e2d8f9913425c9927288\
+         13d658a3334a4070ce585cb907a67604fc74578e84e714c38c6547377fac133e",
+    ]);
+
+    MockTradeWallet { funding_coins, new_addresses, signature_map, internal_key, script_sigs }
+}
+
+fn signature_vec(signatures: &[&'static str]) -> Vec<Signature> {
+    signatures.iter().map(|s| Signature {
+        signature: s.parse().expect("hardcoded signatures should be valid"),
+        sighash_type: TapSighashType::Default,
+    }).collect()
+}
+
+fn signature_map(funding_coins: &[TxOutput], signatures: &[&'static str]) -> BTreeMap<OutPoint, Signature> {
+    funding_coins.iter().map(|o| o.outpoint).zip(signature_vec(signatures)).collect()
+}
+
+fn script_sigs(iks: &[XOnlyPublicKey], signatures: &[&'static str]) -> BTreeMap<XOnlyPublicKey, Vec<Signature>> {
+    iks.iter().map(|k| (*k, signature_vec(signatures))).collect()
+}

--- a/protocol/src/protocol_musig_adaptor.rs
+++ b/protocol/src/protocol_musig_adaptor.rs
@@ -8,14 +8,18 @@ use bdk_wallet::miniscript::{DefiniteDescriptorKey, Descriptor};
 use chain::ChainApi;
 use musig2::secp::{MaybeScalar, Point};
 use musig2::{PartialSignature, PubNonce};
+use wallet::protocol_wallet_api::ProtocolWalletApi;
 
 use crate::multisig::{KeyCtx, PointExt as _, SigCtx};
-use crate::psbt::BoxedTradeWallet;
 use crate::receiver::{Receiver, ReceiverList};
 use crate::script_paths;
 use crate::transaction::{
     DepositTxBuilder, ForwardingTxBuilder, RedirectTxBuilder, TransactionExt as _, WarningTxBuilder,
 };
+
+/// Type-erased wallet handle used by the trade protocol. The concrete wallet may be a
+/// `MemWallet`, a `BMPWallet<Connection>`, or any other type that implements [`ProtocolWalletApi`].
+pub type BoxedTradeWallet = Box<dyn ProtocolWalletApi + Send>;
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 #[expect(clippy::exhaustive_enums)]

--- a/protocol/src/psbt.rs
+++ b/protocol/src/psbt.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::mem;
 
-use bdk_wallet::Wallet;
 use bdk_wallet::bitcoin::amount::CheckedSum as _;
 use bdk_wallet::bitcoin::hashes::Hash as _;
 use bdk_wallet::bitcoin::opcodes::all::{OP_PUSHBYTES_27, OP_RETURN};
@@ -9,14 +8,12 @@ use bdk_wallet::bitcoin::taproot::Signature;
 use bdk_wallet::bitcoin::transaction::Version;
 use bdk_wallet::bitcoin::{
     Address, Amount, FeeRate, Network, OutPoint, Psbt, ScriptBuf, Sequence, TapSighashType,
-    Transaction, TxIn, TxOut, Weight, Witness, XOnlyPublicKey, absolute, psbt, script,
+    Transaction, TxIn, TxOut, VarInt, Weight, Witness, XOnlyPublicKey, absolute, psbt, script,
 };
-use bdk_wallet::rusqlite::Connection;
 use musig2::secp::Scalar;
 use rand::{RngCore, SeedableRng as _};
 use rand_chacha::ChaCha20Rng;
-use wallet::bmp_wallet::BMPWallet;
-use wallet::protocol_wallet_api::{MemWallet, ProtocolWalletApi, WalletErrorKind};
+use wallet::protocol_wallet_api::{ProtocolWalletApi, WalletErrorKind};
 
 use crate::psbt::WalletErrorKind::Other;
 use crate::receiver::Receiver;
@@ -34,8 +31,7 @@ pub const MAX_ALLOWED_HALF_PSBT_OUTPUT_NUM: usize = 126;
 /// Extension trait carrying the trade-deposit-specific wallet operations on top of the
 /// generic [`ProtocolWalletApi`]. Anything that implements `ProtocolWalletApi` plugs in
 /// for free via the default `create_half_deposit_psbt`, which is built on top of
-/// [`ProtocolWalletApi::create_psbt`]. The default only needs to be overridden by mock
-/// impls that don't provide a real `create_psbt` (notably [`MockTradeWallet`]).
+/// [`ProtocolWalletApi::create_psbt`].
 pub trait TradeWallet: ProtocolWalletApi {
     fn create_half_deposit_psbt(
         &mut self,
@@ -44,15 +40,13 @@ pub trait TradeWallet: ProtocolWalletApi {
         trade_fee_receivers: &[Receiver],
         rng: &mut dyn RngCore,
     ) -> Result<Psbt> {
-        let mut recipients: Vec<(ScriptBuf, Amount)> =
-            Vec::with_capacity(1 + trade_fee_receivers.len());
+        let mut recipients = Vec::with_capacity(1 + trade_fee_receivers.len());
         recipients.push((half_deposit_placeholder_spk(rng), deposit_amount));
-        recipients.extend(
-            trade_fee_receivers
-                .iter()
-                .map(|r| (r.address.script_pubkey(), r.amount)),
-        );
-        let mut psbt = ProtocolWalletApi::create_psbt(self, recipients, fee_rate)?;
+        recipients.extend(trade_fee_receivers.iter()
+            .map(|r| (r.address.script_pubkey(), r.amount)));
+
+        let mut psbt = self.create_psbt(recipients, fee_rate)?;
+
         // Calculate tx fee overpay unconditionally, as this performs additional checks on the PSBT:
         let overpay_msat: u64 = half_psbt_fee_overpay_msat(&psbt, fee_rate)
             .ok_or(TransactionErrorKind::Overflow)?
@@ -71,6 +65,8 @@ pub trait TradeWallet: ProtocolWalletApi {
         Ok(psbt)
     }
 }
+
+impl<T: ProtocolWalletApi> TradeWallet for T {}
 
 /// Type-erased wallet handle used by the trade protocol. The concrete wallet may be a
 /// `MemWallet`, a `BMPWallet<Connection>`, or any other type that implements [`TradeWallet`].
@@ -97,13 +93,67 @@ impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> ProtocolWallet
 
     fn create_psbt(
         &mut self,
-        _recipients: Vec<(ScriptBuf, Amount)>,
-        _fee_rate: FeeRate,
+        mut recipients: Vec<(ScriptBuf, Amount)>,
+        fee_rate: FeeRate,
     ) -> Result<Psbt, WalletErrorKind> {
-        unimplemented!(
-            "MockTradeWallet does not implement the generic create_psbt; \
-            the trade protocol uses create_half_deposit_psbt instead"
-        )
+        let fee_cost_msat = |weight: Weight|
+            fee_rate.to_sat_per_kwu().checked_mul(weight.to_wu())
+                .ok_or(Other(TransactionErrorKind::Overflow.into()));
+
+        // Provisionally add a change recipient of zero value. We should never normally use
+        // `new_address()` for change outputs, but this is just a mock.
+        recipients.push((self.new_address()?.script_pubkey(), Amount::ZERO));
+
+        let base_weight = Weight::from_wu_usize(38 + 4 * VarInt::from(recipients.len()).size());
+        let mut output = Vec::with_capacity(recipients.len());
+        let mut cost_msat = fee_cost_msat(base_weight)?;
+
+        for (script_pubkey, value) in recipients {
+            let tx_out = TxOut { value, script_pubkey };
+            cost_msat = (|| cost_msat
+                .checked_add(value.to_sat().checked_mul(1000)?)?
+                .checked_add(fee_cost_msat(tx_out.weight()).ok()?))()
+                .ok_or(Other(TransactionErrorKind::Overflow.into()))?;
+            output.push(tx_out);
+        }
+
+        let mut input = Vec::new();
+        let mut inputs = Vec::new();
+        let mut funds = Amount::ZERO;
+
+        while funds < Amount::from_sat(cost_msat.div_ceil(1000)) {
+            let new_coin = self.funding_coins.next()
+                .ok_or(Other(TransactionErrorKind::MissingTxOutput.into()))?;
+            let new_coin_weight = new_coin.estimated_input_weight()
+                .ok_or(Other(TransactionErrorKind::InvalidPsbt.into()))?;
+            funds = funds.checked_add(new_coin.prevout.value)
+                .ok_or(Other(TransactionErrorKind::Overflow.into()))?;
+            cost_msat = cost_msat.checked_add(fee_cost_msat(new_coin_weight)?)
+                .ok_or(Other(TransactionErrorKind::Overflow.into()))?;
+            input.push(TxIn {
+                previous_output: new_coin.outpoint,
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                ..TxIn::default()
+            });
+            inputs.push(psbt::Input {
+                witness_utxo: Some(new_coin.prevout),
+                ..psbt::Input::default()
+            });
+        }
+
+        let change_output = output.last_mut().expect("tx has a provisional change output");
+        change_output.value = funds - Amount::from_sat(cost_msat.div_ceil(1000));
+        if change_output.value < change_output.script_pubkey.minimal_non_dust() {
+            output.pop();
+        }
+
+        let unsigned_tx = Transaction {
+            version: Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input,
+            output,
+        };
+        Ok(Psbt { inputs, ..Psbt::from_unsigned_tx(unsigned_tx).expect("tx is unsigned by construction") })
     }
 
     fn sign_selected_inputs(
@@ -152,78 +202,6 @@ impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> ProtocolWallet
 
     fn import_private_key(&mut self, _pk: Scalar) {
         unimplemented!("MockTradeWallet does not support importing private keys")
-    }
-}
-
-impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> TradeWallet for MockTradeWallet<Cs, As> {
-    fn create_half_deposit_psbt(
-        &mut self,
-        deposit_amount: Amount,
-        fee_rate: FeeRate,
-        trade_fee_receivers: &[Receiver],
-        rng: &mut dyn RngCore,
-    ) -> Result<Psbt> {
-        const HALF_DEPOSIT_TX_BASE_WEIGHT: Weight = Weight::from_wu(193);
-
-        let fee_cost_msat = |weight: Weight|
-            fee_rate.to_sat_per_kwu().checked_mul(weight.to_wu())
-                .ok_or(TransactionErrorKind::Overflow);
-        let deposit_amount_msat = deposit_amount.to_sat().checked_mul(1000)
-            .ok_or(TransactionErrorKind::Overflow)?;
-
-        let mut input = Vec::new();
-        let mut inputs = Vec::new();
-        let mut output = Vec::with_capacity(trade_fee_receivers.len() + 2);
-
-        output.push(TxOut {
-            value: deposit_amount,
-            script_pubkey: half_deposit_placeholder_spk(rng),
-        });
-        output.extend(trade_fee_receivers.iter().map(TxOut::from));
-        // We should never normally use `new_address()` for change outputs, but this is just a mock:
-        let mut change_output = TxOut { value: Amount::ZERO, script_pubkey: self.new_address()?.script_pubkey() };
-
-        let mut cost_msat = Receiver::total_output_cost_msat(trade_fee_receivers, fee_rate, 2)?
-            .checked_add(deposit_amount_msat)
-            .ok_or(TransactionErrorKind::Overflow)?
-            .checked_add(fee_cost_msat(HALF_DEPOSIT_TX_BASE_WEIGHT)?)
-            .ok_or(TransactionErrorKind::Overflow)?
-            .checked_add(fee_cost_msat(change_output.weight())?)
-            .ok_or(TransactionErrorKind::Overflow)?;
-
-        let mut funds = Amount::ZERO;
-        while funds < Amount::from_sat(cost_msat.div_ceil(1000)) {
-            let new_coin = self.funding_coins.next()
-                .ok_or(TransactionErrorKind::MissingTxOutput)?;
-            let new_coin_weight = new_coin.estimated_input_weight()
-                .ok_or(TransactionErrorKind::InvalidPsbt)?;
-            funds = funds.checked_add(new_coin.prevout.value)
-                .ok_or(TransactionErrorKind::Overflow)?;
-            cost_msat = cost_msat.checked_add(fee_cost_msat(new_coin_weight)?)
-                .ok_or(TransactionErrorKind::Overflow)?;
-            input.push(TxIn {
-                previous_output: new_coin.outpoint,
-                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-                ..TxIn::default()
-            });
-            inputs.push(psbt::Input {
-                witness_utxo: Some(new_coin.prevout),
-                ..psbt::Input::default()
-            });
-        }
-
-        change_output.value = funds - Amount::from_sat(cost_msat.div_ceil(1000));
-        if change_output.value >= change_output.script_pubkey.minimal_non_dust() {
-            output.push(change_output);
-        }
-
-        let unsigned_tx = Transaction {
-            version: Version::TWO,
-            lock_time: absolute::LockTime::ZERO,
-            input,
-            output,
-        };
-        Ok(Psbt { inputs, ..Psbt::from_unsigned_tx(unsigned_tx).expect("tx is unsigned by construction") })
     }
 }
 
@@ -301,12 +279,6 @@ fn signature_map(funding_coins: &[TxOutput], signatures: &[&'static str]) -> BTr
 fn script_sigs(iks: &[XOnlyPublicKey], signatures: &[&'static str]) -> BTreeMap<XOnlyPublicKey, Vec<Signature>> {
     iks.iter().map(|k| (*k, signature_vec(signatures))).collect()
 }
-
-impl TradeWallet for Wallet {}
-
-impl TradeWallet for BMPWallet<Connection> {}
-
-impl TradeWallet for MemWallet {}
 
 trait Redact {
     fn redact_sensitive_fields(&mut self);

--- a/protocol/src/psbt.rs
+++ b/protocol/src/psbt.rs
@@ -1,21 +1,16 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::mem;
 
 use bdk_wallet::bitcoin::amount::CheckedSum as _;
 use bdk_wallet::bitcoin::hashes::Hash as _;
 use bdk_wallet::bitcoin::opcodes::all::{OP_PUSHBYTES_27, OP_RETURN};
-use bdk_wallet::bitcoin::taproot::Signature;
-use bdk_wallet::bitcoin::transaction::Version;
 use bdk_wallet::bitcoin::{
-    Address, Amount, FeeRate, Network, OutPoint, Psbt, ScriptBuf, Sequence, TapSighashType,
-    Transaction, TxIn, TxOut, VarInt, Weight, Witness, XOnlyPublicKey, absolute, psbt, script,
+    Amount, FeeRate, OutPoint, Psbt, ScriptBuf, Sequence, Transaction, TxOut, Weight, psbt, script,
 };
-use musig2::secp::Scalar;
 use rand::{RngCore, SeedableRng as _};
 use rand_chacha::ChaCha20Rng;
-use wallet::protocol_wallet_api::{ProtocolWalletApi, WalletErrorKind};
+use wallet::protocol_wallet_api::ProtocolWalletApi;
 
-use crate::psbt::WalletErrorKind::Other;
 use crate::receiver::Receiver;
 use crate::swap::Swap as _;
 use crate::transaction::{Result, TransactionErrorKind, TxOutput};
@@ -28,7 +23,7 @@ use crate::transaction::{Result, TransactionErrorKind, TxOutput};
 pub const MAX_ALLOWED_HALF_PSBT_INPUT_NUM: usize = 126;
 pub const MAX_ALLOWED_HALF_PSBT_OUTPUT_NUM: usize = 126;
 
-pub(crate) fn create_half_deposit_psbt(
+pub fn create_half_deposit_psbt(
     wallet: &mut (impl ProtocolWalletApi + ?Sized),
     deposit_amount: Amount,
     fee_rate: FeeRate,
@@ -60,215 +55,7 @@ pub(crate) fn create_half_deposit_psbt(
     Ok(psbt)
 }
 
-struct MockTradeWallet<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> {
-    funding_coins: Cs,
-    new_addresses: As,
-    signature_map: BTreeMap<OutPoint, Signature>,
-    internal_key: Option<XOnlyPublicKey>,
-    script_sigs: BTreeMap<XOnlyPublicKey, Vec<Signature>>,
-}
-
-impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> ProtocolWalletApi for MockTradeWallet<Cs, As> {
-    fn network(&self) -> Network { Network::Regtest }
-
-    fn new_address(&mut self) -> Result<Address, WalletErrorKind> {
-        self.new_addresses.next().ok_or_else(|| Other(TransactionErrorKind::MissingAddress.into()))
-    }
-
-    fn new_internal_key(&mut self) -> Result<XOnlyPublicKey, WalletErrorKind> {
-        self.internal_key.take().ok_or_else(|| Other(TransactionErrorKind::MissingAddress.into()))
-    }
-
-    fn create_psbt(
-        &mut self,
-        mut recipients: Vec<(ScriptBuf, Amount)>,
-        fee_rate: FeeRate,
-    ) -> Result<Psbt, WalletErrorKind> {
-        let fee_cost_msat = |weight: Weight|
-            fee_rate.to_sat_per_kwu().checked_mul(weight.to_wu())
-                .ok_or(Other(TransactionErrorKind::Overflow.into()));
-
-        // Provisionally add a change recipient of zero value. We should never normally use
-        // `new_address()` for change outputs, but this is just a mock.
-        recipients.push((self.new_address()?.script_pubkey(), Amount::ZERO));
-
-        let base_weight = Weight::from_wu_usize(38 + 4 * VarInt::from(recipients.len()).size());
-        let mut output = Vec::with_capacity(recipients.len());
-        let mut cost_msat = fee_cost_msat(base_weight)?;
-
-        for (script_pubkey, value) in recipients {
-            let tx_out = TxOut { value, script_pubkey };
-            cost_msat = (|| cost_msat
-                .checked_add(value.to_sat().checked_mul(1000)?)?
-                .checked_add(fee_cost_msat(tx_out.weight()).ok()?))()
-                .ok_or(Other(TransactionErrorKind::Overflow.into()))?;
-            output.push(tx_out);
-        }
-
-        let mut input = Vec::new();
-        let mut inputs = Vec::new();
-        let mut funds = Amount::ZERO;
-
-        while funds < Amount::from_sat(cost_msat.div_ceil(1000)) {
-            let new_coin = self.funding_coins.next()
-                .ok_or(Other(TransactionErrorKind::MissingTxOutput.into()))?;
-            let new_coin_weight = new_coin.estimated_input_weight()
-                .ok_or(Other(TransactionErrorKind::InvalidPsbt.into()))?;
-            funds = funds.checked_add(new_coin.prevout.value)
-                .ok_or(Other(TransactionErrorKind::Overflow.into()))?;
-            cost_msat = cost_msat.checked_add(fee_cost_msat(new_coin_weight)?)
-                .ok_or(Other(TransactionErrorKind::Overflow.into()))?;
-            input.push(TxIn {
-                previous_output: new_coin.outpoint,
-                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-                ..TxIn::default()
-            });
-            inputs.push(psbt::Input {
-                witness_utxo: Some(new_coin.prevout),
-                ..psbt::Input::default()
-            });
-        }
-
-        let change_output = output.last_mut().expect("tx has a provisional change output");
-        change_output.value = funds - Amount::from_sat(cost_msat.div_ceil(1000));
-        if change_output.value < change_output.script_pubkey.minimal_non_dust() {
-            output.pop();
-        }
-
-        let unsigned_tx = Transaction {
-            version: Version::TWO,
-            lock_time: absolute::LockTime::ZERO,
-            input,
-            output,
-        };
-        Ok(Psbt { inputs, ..Psbt::from_unsigned_tx(unsigned_tx).expect("tx is unsigned by construction") })
-    }
-
-    fn sign_selected_inputs(
-        &mut self,
-        psbt: &mut Psbt,
-        is_selected: &dyn Fn(&OutPoint) -> bool,
-    ) -> Result<(), WalletErrorKind> {
-        let mut script_sigs = self.script_sigs.clone();
-
-        for (input, TxIn { previous_output, .. })
-        in psbt.inputs.iter_mut().zip(&psbt.unsigned_tx.input)
-        {
-            if is_selected(previous_output) {
-                for (key, (leaf_hashes, _)) in &input.tap_key_origins {
-                    if let Some(sig) = script_sigs.get_mut(key).and_then(Vec::pop) {
-                        for leaf_hash in leaf_hashes {
-                            input.tap_script_sigs.insert((*key, *leaf_hash), sig);
-                        }
-                    }
-                }
-                if let Some(signature) = self.signature_map.get(previous_output) {
-                    // Mock keyspend:
-                    input.final_script_witness = Some(Witness::p2tr_key_spend(signature));
-                    input.redact_sensitive_fields();
-                } else if input.tap_key_origins.len() == input.tap_script_sigs.len() + 1 {
-                    // Mock script spend (assumes only one path):
-                    if let Some((control_block, (script, _))) = input.tap_scripts.first_key_value()
-                    {
-                        let mut wit = Witness::new();
-                        // For the purpose of the mock, assume that (pubkey, leaf-hash) -> signature
-                        // mappings occur in the opposite order that the signatures need to be added
-                        // to the witness. This won't be true in general.
-                        for sig in input.tap_script_sigs.values().rev() {
-                            wit.push(sig.serialize());
-                        }
-                        wit.push(script.as_bytes());
-                        wit.push(control_block.serialize());
-                        input.final_script_witness = Some(wit);
-                        input.redact_sensitive_fields();
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn import_private_key(&mut self, _pk: Scalar) {
-        unimplemented!("MockTradeWallet does not support importing private keys")
-    }
-}
-
-//noinspection SpellCheckingInspection
-pub fn mock_buyer_trade_wallet() -> impl ProtocolWalletApi {
-    let funding_coins = [
-        "658654575bbbeb46e965bd9eb37fd3be550a7e0fa2d64bc5f218763155602300:0",
-    ].map(TxOutput::mock_1_btc_coin).into_iter();
-    let signature_map = signature_map(funding_coins.as_slice(), &[
-        "f631ae99b4743315b237af9c48ae1f9bb87b6c5404e84d8e3907269218d1bba5\
-         4c397158aa233fd3f2227f4dc46922ef62eb8cc39a06b7a339b33e2401d512c1",
-    ]);
-    let new_addresses = [
-        "bcrt1pgsj9aw0wvs5h6zj780djnu267v6jazmfekwm4g4q4s6ax3w3t0lseqqnjc",
-        "bcrt1pkar3gerekw8f9gef9vn9xz0qypytgacp9wa5saelpksdgct33qdqan7c89",
-        "bcrt1pv537m7m6w0gdrcdn3mqqdpgrk3j400yrdrjwf5c9whyl2f8f4p6q9dn3l9",
-        "bcrt1pzvynlely05x82u40cts3znctmvyskue74xa5zwy0t5ueuv92726szpgpaa",
-    ].map(|a| a.parse::<Address<_>>()
-        .expect("hardcoded addresses should be valid").assume_checked()).into_iter();
-    let internal_key =
-        "51494dc22e24a32fe9dcfbd7e85faf345fa1df296fb49d156e859ef345201295".parse().ok();
-    let script_sigs = script_sigs(internal_key.as_slice(), &[
-        "5564448d3c5f024eaf2c65024a0c6e7a9066eb0390f8ffaeee2feacde310fabf\
-         87f3a8d8ad7fb125d7a6f68a282cfab8cd3178262a1fd0c2d06a598c8c454af8",
-        "652d0abaa3b4f8c7dd85ac9d523d44f768c8e1541aded79165c3cdfb3ba35d62\
-         eef114e89becb490a80cfdab946d2d91748ccea501ceb4f08655dcc2868c0463",
-    ]);
-
-    MockTradeWallet { funding_coins, new_addresses, signature_map, internal_key, script_sigs }
-}
-
-//noinspection SpellCheckingInspection
-pub fn mock_seller_trade_wallet() -> impl ProtocolWalletApi {
-    let funding_coins = [
-        "4a5ecc72ec8db78f11c6785f560a13f6f32eac66d160a8157d30956695ccf523:0",
-        "373b3ca0b9135e9649672772d4659bb5597d06b4694f1fbdbece285823fde0a3:1",
-    ].map(TxOutput::mock_1_btc_coin).into_iter();
-    let signature_map = signature_map(funding_coins.as_slice(), &[
-        "2376111ed79dac9ff6f2d85dfe57d142f6075f4df9381aeab87a941477425224\
-         7555f791ddf82354a3d73fa24955f6c5330ae44b2b238fa74be2eee9a46fcb72",
-        "637f4a624bfc46bdb52e01b923d157a97148210f1a2669716815d3249c615673\
-         17d543868698f30130e0aaf693ce265c544e3db5eda568bffb6ccd03d25a31df",
-    ]);
-    let new_addresses = [
-        "bcrt1p80xu5f0nqjarfnechsmlt488jf3tykx8cva9zeeczlsu4c7x557qr499gz",
-        "bcrt1pt5xd4aqe9whmvlz78mt39rvdlgpp6hujs5ggwan5285zjnsf73rq20k456",
-        "bcrt1pwxlp4v9v7v03nx0e7vunlc87d4936wnyqegw0fuahudypan64wysefpqzy",
-        "bcrt1pw4s5zvfm665fq9u6uwn9g7gwna658s939dvvf9wg63yede8kvyms5pmalx",
-        "bcrt1pe3kcs085e8qej9aqqx6qryv2qsfxzywy9xd8pryzwemv2dghdqgscylr69",
-    ].map(|a| a.parse::<Address<_>>()
-        .expect("hardcoded addresses should be valid").assume_checked()).into_iter();
-    let internal_key =
-        "fcba7ecf41bc7e1be4ee122d9d22e3333671eb0a3a87b5cdf099d59874e1940f".parse().ok();
-    let script_sigs = script_sigs(internal_key.as_slice(), &[
-        "87790f7eb3e98eb1b4dadc55ff5762275c4e3c02c6491abb26c8eabfada55b4b\
-         3f2627f627919d667be8f191a1b275b01549ab24e5eeda0019f83c658840500e",
-        "52fe2e44a4789a0f9bc406da144dcacca2621d2c1286e2d8f9913425c9927288\
-         13d658a3334a4070ce585cb907a67604fc74578e84e714c38c6547377fac133e",
-    ]);
-
-    MockTradeWallet { funding_coins, new_addresses, signature_map, internal_key, script_sigs }
-}
-
-fn signature_vec(signatures: &[&'static str]) -> Vec<Signature> {
-    signatures.iter().map(|s| Signature {
-        signature: s.parse().expect("hardcoded signatures should be valid"),
-        sighash_type: TapSighashType::Default,
-    }).collect()
-}
-
-fn signature_map(funding_coins: &[TxOutput], signatures: &[&'static str]) -> BTreeMap<OutPoint, Signature> {
-    funding_coins.iter().map(|o| o.outpoint).zip(signature_vec(signatures)).collect()
-}
-
-fn script_sigs(iks: &[XOnlyPublicKey], signatures: &[&'static str]) -> BTreeMap<XOnlyPublicKey, Vec<Signature>> {
-    iks.iter().map(|k| (*k, signature_vec(signatures))).collect()
-}
-
-trait Redact {
+pub trait Redact {
     fn redact_sensitive_fields(&mut self);
 }
 
@@ -309,7 +96,7 @@ impl Redact for psbt::Output {
 // When the half-PSBTs are merged, the placeholders are replaced with the actual payout UTXOs. The
 // injected randomness of the (trade-private) OP_RETURN datagrams ensures that a _deterministic_
 // shuffling of the merged deposit PSBT inputs & outputs is unpredictable to any 3rd party.
-pub(crate) fn half_deposit_placeholder_spk<R: RngCore + ?Sized>(rng: &mut R) -> ScriptBuf {
+fn half_deposit_placeholder_spk<R: RngCore + ?Sized>(rng: &mut R) -> ScriptBuf {
     let mut data = [0u8; 27];
     rng.fill_bytes(&mut data);
     script::Builder::new()
@@ -318,11 +105,11 @@ pub(crate) fn half_deposit_placeholder_spk<R: RngCore + ?Sized>(rng: &mut R) -> 
         .into_script()
 }
 
-pub(crate) fn prevout_set(psbt: &Psbt) -> BTreeSet<OutPoint> {
+pub fn prevout_set(psbt: &Psbt) -> BTreeSet<OutPoint> {
     psbt.unsigned_tx.input.iter().map(|input| input.previous_output).collect()
 }
 
-pub(crate) fn check_placeholder_output(psbt: &Psbt, expected_deposit: Amount) -> Result<()> {
+pub fn check_placeholder_output(psbt: &Psbt, expected_deposit: Amount) -> Result<()> {
     let Some(TxOut { value, script_pubkey }) = psbt.unsigned_tx.output.first() else {
         return Err(TransactionErrorKind::InvalidPsbt);
     };
@@ -333,7 +120,7 @@ pub(crate) fn check_placeholder_output(psbt: &Psbt, expected_deposit: Amount) ->
     Ok(())
 }
 
-pub(crate) fn check_receiver_outputs(psbt: &Psbt, trade_fee_receivers: &[Receiver]) -> Result<()> {
+pub fn check_receiver_outputs(psbt: &Psbt, trade_fee_receivers: &[Receiver]) -> Result<()> {
     if psbt.unsigned_tx.output.len() <= trade_fee_receivers.len() ||
         (0..trade_fee_receivers.len())
             .any(|i| psbt.unsigned_tx.output[i + 1] != (&trade_fee_receivers[i]).into()) {
@@ -390,7 +177,7 @@ fn is_well_formed(psbt: &Psbt) -> bool {
         psbt.unsigned_tx.input.iter().all(|i| i.script_sig.is_empty() && i.witness.is_empty())
 }
 
-pub(crate) fn merge_psbt_halves(
+pub fn merge_psbt_halves(
     buyer_psbt: &Psbt,
     seller_psbt: &Psbt,
     target_fee_rate: FeeRate,
@@ -463,7 +250,7 @@ pub(crate) fn merge_psbt_halves(
     Ok(merged_psbt)
 }
 
-pub(crate) fn set_payouts_and_shuffle(psbt: &mut Psbt, buyer_payout: &mut TxOutput, seller_payout: &mut TxOutput) {
+pub fn set_payouts_and_shuffle(psbt: &mut Psbt, buyer_payout: &mut TxOutput, seller_payout: &mut TxOutput) {
     let seed = psbt.unsigned_tx.compute_txid().to_byte_array();
     psbt.unsigned_tx.output[0] = buyer_payout.prevout.clone();
     psbt.unsigned_tx.output[1] = seller_payout.prevout.clone();
@@ -480,7 +267,7 @@ pub(crate) fn set_payouts_and_shuffle(psbt: &mut Psbt, buyer_payout: &mut TxOutp
     [buyer_payout.outpoint.txid, seller_payout.outpoint.txid] = [txid; 2];
 }
 
-pub(crate) fn extract_signed_tx(psbt: &Psbt) -> Result<Transaction> {
+pub fn extract_signed_tx(psbt: &Psbt) -> Result<Transaction> {
     if !is_well_formed(psbt) || psbt.inputs.iter().any(|input| input.final_script_sig.is_some()) {
         return Err(TransactionErrorKind::InvalidPsbt);
     }
@@ -495,7 +282,8 @@ pub(crate) fn extract_signed_tx(psbt: &Psbt) -> Result<Transaction> {
 mod tests {
     use std::sync::LazyLock;
 
-    use bdk_wallet::bitcoin::secp256k1;
+    use bdk_wallet::bitcoin::transaction::Version;
+    use bdk_wallet::bitcoin::{Address, Network, TxIn, absolute, secp256k1};
     use bdk_wallet::miniscript::psbt::PsbtInputExt as _;
     use bdk_wallet::psbt::PsbtUtils as _;
     use bdk_wallet::{KeychainKind, test_utils};

--- a/protocol/src/psbt.rs
+++ b/protocol/src/psbt.rs
@@ -16,8 +16,9 @@ use musig2::secp::Scalar;
 use rand::{RngCore, SeedableRng as _};
 use rand_chacha::ChaCha20Rng;
 use wallet::bmp_wallet::BMPWallet;
-use wallet::protocol_wallet_api::{MemWallet, ProtocolWalletApi};
+use wallet::protocol_wallet_api::{MemWallet, ProtocolWalletApi, WalletErrorKind};
 
+use crate::psbt::WalletErrorKind::Other;
 use crate::receiver::Receiver;
 use crate::swap::Swap as _;
 use crate::transaction::{Result, TransactionErrorKind, TxOutput};
@@ -86,23 +87,19 @@ struct MockTradeWallet<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Addres
 impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> ProtocolWalletApi for MockTradeWallet<Cs, As> {
     fn network(&self) -> Network { Network::Regtest }
 
-    fn new_address(&mut self) -> anyhow::Result<Address> {
-        self.new_addresses
-            .next()
-            .ok_or_else(|| anyhow::Error::from(TransactionErrorKind::MissingAddress))
+    fn new_address(&mut self) -> Result<Address, WalletErrorKind> {
+        self.new_addresses.next().ok_or_else(|| Other(TransactionErrorKind::MissingAddress.into()))
     }
 
-    fn new_internal_key(&mut self) -> anyhow::Result<XOnlyPublicKey> {
-        self.internal_key
-            .take()
-            .ok_or_else(|| anyhow::Error::from(TransactionErrorKind::MissingAddress))
+    fn new_internal_key(&mut self) -> Result<XOnlyPublicKey, WalletErrorKind> {
+        self.internal_key.take().ok_or_else(|| Other(TransactionErrorKind::MissingAddress.into()))
     }
 
     fn create_psbt(
         &mut self,
         _recipients: Vec<(ScriptBuf, Amount)>,
         _fee_rate: FeeRate,
-    ) -> anyhow::Result<Psbt> {
+    ) -> Result<Psbt, WalletErrorKind> {
         unimplemented!(
             "MockTradeWallet does not implement the generic create_psbt; \
             the trade protocol uses create_half_deposit_psbt instead"
@@ -113,7 +110,7 @@ impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> ProtocolWallet
         &mut self,
         psbt: &mut Psbt,
         is_selected: &dyn Fn(&OutPoint) -> bool,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), WalletErrorKind> {
         let mut script_sigs = self.script_sigs.clone();
 
         for (input, TxIn { previous_output, .. })

--- a/protocol/src/psbt.rs
+++ b/protocol/src/psbt.rs
@@ -38,9 +38,7 @@ pub fn create_half_deposit_psbt(
     let mut psbt = wallet.create_psbt(recipients, fee_rate)?;
 
     // Calculate tx fee overpay unconditionally, as this performs additional checks on the PSBT:
-    let overpay_msat: u64 = half_psbt_fee_overpay_msat(&psbt, fee_rate)
-        .ok_or(TransactionErrorKind::Overflow)?
-        .try_into()
+    let overpay_msat = u64::try_from(half_psbt_fee_overpay_msat(&psbt, fee_rate)?)
         .map_err(|_| TransactionErrorKind::InvalidPsbt)?;
     let change_output_index = 1 + trade_fee_receivers.len();
     if psbt.unsigned_tx.output.len() > change_output_index {
@@ -129,18 +127,19 @@ pub fn check_receiver_outputs(psbt: &Psbt, trade_fee_receivers: &[Receiver]) -> 
     Ok(())
 }
 
-fn input_coin(psbt: &Psbt, index: usize) -> Option<TxOutput> {
+fn input_coin(psbt: &Psbt, index: usize) -> Result<TxOutput> {
     if psbt.unsigned_tx.input[index].sequence != Sequence::ENABLE_RBF_NO_LOCKTIME {
         // Enforce that all deposit PSBT inputs have a sequence number of 0xFFFFFFFD.
-        return None;
+        return Err(TransactionErrorKind::InvalidPsbt);
     }
-    Some(TxOutput {
+    Ok(TxOutput {
         outpoint: psbt.unsigned_tx.input[index].previous_output,
-        prevout: psbt.inputs[index].witness_utxo.clone()?,
+        prevout: psbt.inputs[index].witness_utxo.clone()
+            .ok_or(TransactionErrorKind::InvalidPsbt)?,
     })
 }
 
-fn half_psbt_fee_overpay_msat(psbt: &Psbt, target_fee_rate: FeeRate) -> Option<i64> {
+fn half_psbt_fee_overpay_msat(psbt: &Psbt, target_fee_rate: FeeRate) -> Result<i64> {
     const INPUT_NON_WITNESS_WEIGHT: Weight = Weight::from_wu(164);
 
     // This is the extra weight of witness vs non-witness consensus-serialization (2 wu) minus 1 wu
@@ -150,25 +149,26 @@ fn half_psbt_fee_overpay_msat(psbt: &Psbt, target_fee_rate: FeeRate) -> Option<i
 
     if psbt.inputs.len() > MAX_ALLOWED_HALF_PSBT_INPUT_NUM ||
         psbt.outputs.len() > MAX_ALLOWED_HALF_PSBT_OUTPUT_NUM {
-        return None;
+        return Err(TransactionErrorKind::InvalidPsbt);
     }
     let mut signed_tx_weight = psbt.unsigned_tx.weight() + EXTRA_WEIGHT
         - INPUT_NON_WITNESS_WEIGHT * psbt.inputs.len() as u64;
     let mut input_amount = Amount::ZERO;
 
     for i in 0..psbt.inputs.len() {
-        // FIXME: This will lead to an overflow error if a corrupted or disallowed input coin is
-        //  encountered, instead of an invalid PSBT error as it should:
         let coin = input_coin(psbt, i)?;
-        signed_tx_weight += coin.estimated_input_weight()?;
-        input_amount = input_amount.checked_add(coin.prevout.value)?;
+        signed_tx_weight += coin.estimated_input_weight()
+            .ok_or(TransactionErrorKind::InvalidPsbt)?;
+        input_amount = input_amount.checked_add(coin.prevout.value)
+            .ok_or(TransactionErrorKind::Overflow)?;
     }
-    let output_amount = psbt.unsigned_tx.output.iter().map(|o| o.value).checked_sum()?;
+    (|| {
+        let output_amount = psbt.unsigned_tx.output.iter().map(|o| o.value).checked_sum()?;
+        let actual_fee_msat = input_amount.checked_sub(output_amount)?.to_sat().checked_mul(1000)?;
+        let target_fee_msat = target_fee_rate.to_sat_per_kwu().checked_mul(signed_tx_weight.to_wu())?;
 
-    let actual_fee_msat = input_amount.checked_sub(output_amount)?.to_sat().checked_mul(1000)?;
-    let target_fee_msat = target_fee_rate.to_sat_per_kwu().checked_mul(signed_tx_weight.to_wu())?;
-
-    Some(i64::try_from(actual_fee_msat).ok()? - i64::try_from(target_fee_msat).ok()?)
+        Some(i64::try_from(actual_fee_msat).ok()? - i64::try_from(target_fee_msat).ok()?)
+    })().ok_or(TransactionErrorKind::Overflow)
 }
 
 fn is_well_formed(psbt: &Psbt) -> bool {
@@ -195,10 +195,8 @@ pub fn merge_psbt_halves(
         return Err(TransactionErrorKind::InvalidPsbt);
     }
 
-    let buyer_overpay_msat = half_psbt_fee_overpay_msat(buyer_psbt, target_fee_rate)
-        .ok_or(TransactionErrorKind::Overflow)?;
-    let seller_overpay_msat = half_psbt_fee_overpay_msat(seller_psbt, target_fee_rate)
-        .ok_or(TransactionErrorKind::Overflow)?;
+    let buyer_overpay_msat = half_psbt_fee_overpay_msat(buyer_psbt, target_fee_rate)?;
+    let seller_overpay_msat = half_psbt_fee_overpay_msat(seller_psbt, target_fee_rate)?;
     if buyer_overpay_msat.is_negative() || seller_overpay_msat.is_negative() {
         return Err(TransactionErrorKind::InvalidPsbt);
     }
@@ -315,7 +313,7 @@ mod tests {
         assert_eq!([40_000, 5_000, 3_202], psbt.unsigned_tx.output.first_chunk().unwrap().clone()
             .map(|o| o.value.to_sat()));
 
-        let overpay_msat = half_psbt_fee_overpay_msat(&psbt, fee_rate).unwrap();
+        let overpay_msat = half_psbt_fee_overpay_msat(&psbt, fee_rate)?;
         assert!((0..1000).contains(&overpay_msat));
 
         // (The PSBT halves would not ever be signed in production, only the merged and shuffled

--- a/protocol/src/psbt.rs
+++ b/protocol/src/psbt.rs
@@ -28,49 +28,37 @@ use crate::transaction::{Result, TransactionErrorKind, TxOutput};
 pub const MAX_ALLOWED_HALF_PSBT_INPUT_NUM: usize = 126;
 pub const MAX_ALLOWED_HALF_PSBT_OUTPUT_NUM: usize = 126;
 
-/// Extension trait carrying the trade-deposit-specific wallet operations on top of the
-/// generic [`ProtocolWalletApi`]. Anything that implements `ProtocolWalletApi` plugs in
-/// for free via the default `create_half_deposit_psbt`, which is built on top of
-/// [`ProtocolWalletApi::create_psbt`].
-pub trait TradeWallet: ProtocolWalletApi {
-    fn create_half_deposit_psbt(
-        &mut self,
-        deposit_amount: Amount,
-        fee_rate: FeeRate,
-        trade_fee_receivers: &[Receiver],
-        rng: &mut dyn RngCore,
-    ) -> Result<Psbt> {
-        let mut recipients = Vec::with_capacity(1 + trade_fee_receivers.len());
-        recipients.push((half_deposit_placeholder_spk(rng), deposit_amount));
-        recipients.extend(trade_fee_receivers.iter()
-            .map(|r| (r.address.script_pubkey(), r.amount)));
+pub(crate) fn create_half_deposit_psbt(
+    wallet: &mut (impl ProtocolWalletApi + ?Sized),
+    deposit_amount: Amount,
+    fee_rate: FeeRate,
+    trade_fee_receivers: &[Receiver],
+    rng: &mut dyn RngCore,
+) -> Result<Psbt> {
+    let mut recipients = Vec::with_capacity(1 + trade_fee_receivers.len());
+    recipients.push((half_deposit_placeholder_spk(rng), deposit_amount));
+    recipients.extend(trade_fee_receivers.iter()
+        .map(|r| (r.address.script_pubkey(), r.amount)));
 
-        let mut psbt = self.create_psbt(recipients, fee_rate)?;
+    let mut psbt = wallet.create_psbt(recipients, fee_rate)?;
 
-        // Calculate tx fee overpay unconditionally, as this performs additional checks on the PSBT:
-        let overpay_msat: u64 = half_psbt_fee_overpay_msat(&psbt, fee_rate)
-            .ok_or(TransactionErrorKind::Overflow)?
-            .try_into()
-            .map_err(|_| TransactionErrorKind::InvalidPsbt)?;
-        let change_output_index = 1 + trade_fee_receivers.len();
-        if psbt.unsigned_tx.output.len() > change_output_index {
-            // Correct any tx fee overpay due to overly conservative input witness size estimation
-            // by BDK (as each witness is assumed to potentially have a non-default sighash type in
-            // the case of p2tr and not grind for low R in the case of p2wpkh), and also due to the
-            // fact that each would-be-signed half-deposit PSBT is 1 wu bigger than ideal.
-            let overpay = Amount::from_sat(overpay_msat / 1000);
-            psbt.unsigned_tx.output[change_output_index].value += overpay;
-        }
-        psbt.redact_sensitive_fields();
-        Ok(psbt)
+    // Calculate tx fee overpay unconditionally, as this performs additional checks on the PSBT:
+    let overpay_msat: u64 = half_psbt_fee_overpay_msat(&psbt, fee_rate)
+        .ok_or(TransactionErrorKind::Overflow)?
+        .try_into()
+        .map_err(|_| TransactionErrorKind::InvalidPsbt)?;
+    let change_output_index = 1 + trade_fee_receivers.len();
+    if psbt.unsigned_tx.output.len() > change_output_index {
+        // Correct any tx fee overpay due to overly conservative input witness size estimation by
+        // BDK (as each witness is assumed to potentially have a non-default sighash type in the
+        // case of P2TR and not grind for low R in the case of P2WPKH), and also due to the fact
+        // that each would-be-signed half-deposit PSBT is 1 wu bigger than ideal.
+        let overpay = Amount::from_sat(overpay_msat / 1000);
+        psbt.unsigned_tx.output[change_output_index].value += overpay;
     }
+    psbt.redact_sensitive_fields();
+    Ok(psbt)
 }
-
-impl<T: ProtocolWalletApi> TradeWallet for T {}
-
-/// Type-erased wallet handle used by the trade protocol. The concrete wallet may be a
-/// `MemWallet`, a `BMPWallet<Connection>`, or any other type that implements [`TradeWallet`].
-pub type BoxedTradeWallet = Box<dyn TradeWallet + Send>;
 
 struct MockTradeWallet<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> {
     funding_coins: Cs,
@@ -206,7 +194,7 @@ impl<Cs: Iterator<Item = TxOutput>, As: Iterator<Item = Address>> ProtocolWallet
 }
 
 //noinspection SpellCheckingInspection
-pub fn mock_buyer_trade_wallet() -> impl TradeWallet {
+pub fn mock_buyer_trade_wallet() -> impl ProtocolWalletApi {
     let funding_coins = [
         "658654575bbbeb46e965bd9eb37fd3be550a7e0fa2d64bc5f218763155602300:0",
     ].map(TxOutput::mock_1_btc_coin).into_iter();
@@ -234,7 +222,7 @@ pub fn mock_buyer_trade_wallet() -> impl TradeWallet {
 }
 
 //noinspection SpellCheckingInspection
-pub fn mock_seller_trade_wallet() -> impl TradeWallet {
+pub fn mock_seller_trade_wallet() -> impl ProtocolWalletApi {
     let funding_coins = [
         "4a5ecc72ec8db78f11c6785f560a13f6f32eac66d160a8157d30956695ccf523:0",
         "373b3ca0b9135e9649672772d4659bb5597d06b4694f1fbdbece285823fde0a3:1",
@@ -535,7 +523,7 @@ mod tests {
 
         // Create a test half-deposit PSBT with one 50_000 sat input, one 40_000 sat OP_RETURN
         // output, one 5_000 sat trade fee output and one change output.
-        let mut psbt = wallet.create_half_deposit_psbt(deposit_amount, fee_rate, &trade_fee_receivers, &mut rng)?;
+        let mut psbt = create_half_deposit_psbt(&mut wallet, deposit_amount, fee_rate, &trade_fee_receivers, &mut rng)?;
         assert_eq!([40_000, 5_000, 3_202], psbt.unsigned_tx.output.first_chunk().unwrap().clone()
             .map(|o| o.value.to_sat()));
 

--- a/protocol/src/transaction.rs
+++ b/protocol/src/transaction.rs
@@ -668,7 +668,7 @@ impl WithFixedInputs<2> for CustomPayoutTxBuilder {
     fn inputs(&self) -> Result<[&TxOutput; 2]> { Ok([self.buyer_input()?, self.seller_input()?]) }
 }
 
-pub type Result<T, E = TransactionErrorKind> = std::result::Result<T, E>;
+pub(crate) type Result<T, E = TransactionErrorKind> = std::result::Result<T, E>;
 
 #[derive(Error, Debug)]
 #[error(transparent)]
@@ -710,12 +710,9 @@ pub enum TransactionErrorKind {
     SigFromSlice(#[from] bdk_wallet::bitcoin::taproot::SigFromSliceError),
     Psbt(#[from] bdk_wallet::bitcoin::psbt::Error),
     ExtractTx(#[from] Box<ExtractTxError>),
-    CreateTx(#[from] bdk_wallet::error::CreateTxError),
-    Signer(#[from] bdk_wallet::signer::SignerError),
     Miniscript(#[from] bdk_wallet::miniscript::Error),
     Conversion(#[from] bdk_wallet::miniscript::descriptor::ConversionError),
     Wallet(#[from] wallet::protocol_wallet_api::WalletErrorKind),
-    Anyhow(#[from] anyhow::Error),
 }
 
 impl From<ExtractTxError> for TransactionErrorKind {

--- a/protocol/src/transaction.rs
+++ b/protocol/src/transaction.rs
@@ -728,7 +728,7 @@ mod tests {
     use rand_chacha::ChaCha20Rng;
 
     use super::*;
-    use crate::psbt::{mock_buyer_trade_wallet, mock_seller_trade_wallet};
+    use crate::mocks::{mock_buyer_trade_wallet, mock_seller_trade_wallet};
     use crate::receiver::Receiver;
     use crate::script_paths::deposit_payout_descriptor;
 

--- a/protocol/src/transaction.rs
+++ b/protocol/src/transaction.rs
@@ -16,11 +16,9 @@ use paste::paste;
 use rand::RngCore;
 use relative::LockTime;
 use thiserror::Error;
+use wallet::protocol_wallet_api::ProtocolWalletApi;
 
-use crate::psbt::{
-    TradeWallet, check_placeholder_output, check_receiver_outputs, extract_signed_tx,
-    merge_psbt_halves, prevout_set, set_payouts_and_shuffle,
-};
+use crate::psbt;
 use crate::receiver::ReceiverList;
 
 pub const REGTEST_WARNING_LOCK_TIME: LockTime = LockTime::from_height(5);
@@ -263,38 +261,38 @@ impl DepositTxBuilder {
 
     pub fn init_buyers_half_psbt(
         &mut self,
-        trade_wallet: &mut (impl TradeWallet + ?Sized),
+        wallet: &mut (impl ProtocolWalletApi + ?Sized),
         rng: &mut dyn RngCore,
     ) -> Result<&mut Self> {
         let deposit_amount = *self.buyers_security_deposit()?;
         let fee_rate = *self.fee_rate()?;
         Ok(self.set_buyers_half_psbt(
-            trade_wallet.create_half_deposit_psbt(deposit_amount, fee_rate, &[], rng)?))
+            psbt::create_half_deposit_psbt(wallet, deposit_amount, fee_rate, &[], rng)?))
     }
 
     pub fn init_sellers_half_psbt(
         &mut self,
-        trade_wallet: &mut (impl TradeWallet + ?Sized),
+        wallet: &mut (impl ProtocolWalletApi + ?Sized),
         rng: &mut dyn RngCore,
     ) -> Result<&mut Self> {
         let deposit_amount = self.sellers_trade_deposit()?;
         let fee_rate = *self.fee_rate()?;
         let trade_fee_receivers = self.trade_fee_receivers()?;
         Ok(self.set_sellers_half_psbt(
-            trade_wallet.create_half_deposit_psbt(deposit_amount, fee_rate, trade_fee_receivers, rng)?))
+            psbt::create_half_deposit_psbt(wallet, deposit_amount, fee_rate, trade_fee_receivers, rng)?))
     }
 
     pub fn compute_unsigned_tx(&mut self) -> Result<&mut Self> {
         // Check that the placeholder output & receiver outputs of each PSBT half are correct.
         let [buyer_psbt, seller_psbt] = [self.buyers_half_psbt()?, self.sellers_half_psbt()?];
-        check_placeholder_output(buyer_psbt, *self.buyers_security_deposit()?)?;
-        check_placeholder_output(seller_psbt, self.sellers_trade_deposit()?)?;
-        check_receiver_outputs(seller_psbt, self.trade_fee_receivers()?)?;
+        psbt::check_placeholder_output(buyer_psbt, *self.buyers_security_deposit()?)?;
+        psbt::check_placeholder_output(seller_psbt, self.sellers_trade_deposit()?)?;
+        psbt::check_receiver_outputs(seller_psbt, self.trade_fee_receivers()?)?;
 
         // Compute a raw merged PSBT.
         let target_fee_rate = *self.fee_rate()?;
         let num_receivers = self.trade_fee_receivers()?.len();
-        let mut psbt = merge_psbt_halves(buyer_psbt, seller_psbt, target_fee_rate, num_receivers)?;
+        let mut psbt = psbt::merge_psbt_halves(buyer_psbt, seller_psbt, target_fee_rate, num_receivers)?;
 
         // Set the payout outputs of the PSBT and shuffle all its inputs and outputs.
         let mut buyer_payout = TxOutput::new(OutPoint::null(), TxOut {
@@ -306,7 +304,7 @@ impl DepositTxBuilder {
             value: *self.sellers_security_deposit()?,
             script_pubkey: self.seller_payout_address()?.script_pubkey(),
         });
-        set_payouts_and_shuffle(&mut psbt, &mut buyer_payout, &mut seller_payout);
+        psbt::set_payouts_and_shuffle(&mut psbt, &mut buyer_payout, &mut seller_payout);
         psbt.unsigned_tx.check_no_dust_outputs()?;
 
         // Initialize the computed fields.
@@ -320,25 +318,25 @@ impl DepositTxBuilder {
 
     pub fn sign_buyer_inputs(
         &mut self,
-        trade_wallet: &mut (impl TradeWallet + ?Sized),
+        wallet: &mut (impl ProtocolWalletApi + ?Sized),
     ) -> Result<&mut Self> {
-        self.sign_matching_inputs(trade_wallet, &prevout_set(self.buyers_half_psbt()?))
+        self.sign_matching_inputs(wallet, &psbt::prevout_set(self.buyers_half_psbt()?))
     }
 
     pub fn sign_seller_inputs(
         &mut self,
-        trade_wallet: &mut (impl TradeWallet + ?Sized),
+        wallet: &mut (impl ProtocolWalletApi + ?Sized),
     ) -> Result<&mut Self> {
-        self.sign_matching_inputs(trade_wallet, &prevout_set(self.sellers_half_psbt()?))
+        self.sign_matching_inputs(wallet, &psbt::prevout_set(self.sellers_half_psbt()?))
     }
 
     fn sign_matching_inputs(
         &mut self,
-        trade_wallet: &mut (impl TradeWallet + ?Sized),
+        wallet: &mut (impl ProtocolWalletApi + ?Sized),
         prevouts: &BTreeSet<OutPoint>,
     ) -> Result<&mut Self> {
         let psbt = self.psbt.as_mut().ok_or(TransactionErrorKind::MissingTransaction)?;
-        trade_wallet.sign_selected_inputs(psbt, &|o| prevouts.contains(o))?;
+        wallet.sign_selected_inputs(psbt, &|o| prevouts.contains(o))?;
         Ok(self)
     }
 
@@ -347,7 +345,7 @@ impl DepositTxBuilder {
         Ok(self)
     }
 
-    pub fn signed_tx(&self) -> Result<Transaction> { extract_signed_tx(self.psbt()?) }
+    pub fn signed_tx(&self) -> Result<Transaction> { psbt::extract_signed_tx(self.psbt()?) }
 }
 
 #[derive(Default)]
@@ -649,10 +647,10 @@ impl CustomPayoutTxBuilder {
 
     pub fn sign_partial(
         &mut self,
-        trade_wallet: &mut (impl TradeWallet + ?Sized),
+        wallet: &mut (impl ProtocolWalletApi + ?Sized),
     ) -> Result<&mut Self> {
         let psbt = self.psbt.as_mut().ok_or(TransactionErrorKind::MissingTransaction)?;
-        trade_wallet.sign_selected_inputs(psbt, &|_| true)?;
+        wallet.sign_selected_inputs(psbt, &|_| true)?;
         Ok(self)
     }
 
@@ -661,7 +659,7 @@ impl CustomPayoutTxBuilder {
         Ok(self)
     }
 
-    pub fn signed_tx(&self) -> Result<Transaction> { extract_signed_tx(self.psbt()?) }
+    pub fn signed_tx(&self) -> Result<Transaction> { psbt::extract_signed_tx(self.psbt()?) }
 }
 
 impl WithFixedInputs<2> for CustomPayoutTxBuilder {

--- a/protocol/tests/protocol_integration_tests.rs
+++ b/protocol/tests/protocol_integration_tests.rs
@@ -6,8 +6,7 @@ use bitcoin::{Amount, FeeRate, Network, TapSighashType};
 use bmp_tracing::tracing;
 use musig2::KeyAggContext;
 use musig2::secp::Point;
-use protocol::protocol_musig_adaptor::{BMPContext, BMPProtocol, ProtocolRole};
-use protocol::psbt::BoxedTradeWallet;
+use protocol::protocol_musig_adaptor::{BMPContext, BMPProtocol, BoxedTradeWallet, ProtocolRole};
 use protocol::transaction::{CustomPayoutTxBuilder, TransactionExt as _};
 use testenv::TestEnv;
 use wallet::bmp_wallet::{BMPWallet, WalletApi as _};
@@ -24,7 +23,8 @@ fn test_initial_tx_creation() -> anyhow::Result<()> {
 /// Single entry point used by every test below to obtain a funded trade wallet. The concrete
 /// backend (`MemWallet` vs `BMPWallet<Connection>`) is selected by the `WALLET_BACKEND`
 /// environment variable (`mem` or `bmp`); it defaults to `bmp` when unset. Both implement
-/// [`TradeWallet`] and are interchangeable from the protocol's point of view.
+/// [`wallet::protocol_wallet_api::ProtocolWalletApi`] and are interchangeable from the protocol's
+/// point of view.
 pub fn funded_wallet(env: &mut TestEnv) -> BoxedTradeWallet {
     // TODO need to abstract sync(), so we can simplify this.
     match std::env::var("WALLET_BACKEND")

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -9,14 +9,14 @@ use guardian::ArcMutexGuardian;
 use musig2::secp::{MaybeScalar, Point, Scalar};
 use musig2::{PartialSignature, PubNonce};
 use protocol::multisig::{KeyCtx, KeyPair, PointExt as _, SigCtx};
-use protocol::psbt::{self, TradeWallet};
 use protocol::receiver::{Receiver, ReceiverList};
-use protocol::script_paths;
 use protocol::transaction::{
     CustomPayoutTxBuilder, DepositTxBuilder, ForwardingTxBuilder, NetworkParams as _,
     RedirectTxBuilder, TransactionExt as _, WarningTxBuilder,
 };
+use protocol::{psbt, script_paths};
 use thiserror::Error;
+use wallet::protocol_wallet_api::ProtocolWalletApi;
 
 use crate::storage::{ByRef, ByVal, Storage};
 
@@ -44,7 +44,7 @@ pub static TRADE_MODELS: LazyLock<TradeModelMemoryStore> = LazyLock::new(|| Mute
 pub struct TradeModel {
     trade_id: String,
     my_role: Role,
-    trade_wallet: Option<Arc<Mutex<dyn TradeWallet + Send + 'static>>>,
+    trade_wallet: Option<Arc<Mutex<dyn ProtocolWalletApi + Send + 'static>>>,
     keys: Keys,
     deposit_tx: DepositTx,
     swap_tx: SwapTx,
@@ -189,7 +189,7 @@ impl TradeModel {
         matches!(self.my_role, Role::BuyerAsMaker | Role::BuyerAsTaker)
     }
 
-    fn trade_wallet(&self) -> Result<ArcMutexGuardian<dyn TradeWallet + Send + 'static>> {
+    fn trade_wallet(&self) -> Result<ArcMutexGuardian<dyn ProtocolWalletApi + Send + 'static>> {
         Ok(ArcMutexGuardian::take(self.trade_wallet.clone()
             .ok_or(ProtocolErrorKind::MissingTradeWallet)?).unwrap())
     }

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -14,7 +14,7 @@ use protocol::transaction::{
     CustomPayoutTxBuilder, DepositTxBuilder, ForwardingTxBuilder, NetworkParams as _,
     RedirectTxBuilder, TransactionExt as _, WarningTxBuilder,
 };
-use protocol::{psbt, script_paths};
+use protocol::{mocks, script_paths};
 use thiserror::Error;
 use wallet::protocol_wallet_api::ProtocolWalletApi;
 
@@ -171,9 +171,9 @@ impl TradeModel {
     pub fn new(trade_id: String, my_role: Role) -> Self {
         let mut trade_model = Self { trade_id, my_role, ..Default::default() };
         let network = trade_model.trade_wallet.insert(if trade_model.am_buyer() {
-            Arc::new(Mutex::new(psbt::mock_buyer_trade_wallet()))
+            Arc::new(Mutex::new(mocks::mock_buyer_trade_wallet()))
         } else {
-            Arc::new(Mutex::new(psbt::mock_seller_trade_wallet()))
+            Arc::new(Mutex::new(mocks::mock_seller_trade_wallet()))
         }).lock().unwrap().network();
         for txs in [&mut trade_model.buyer_txs, &mut trade_model.seller_txs] {
             txs.warning.builder.set_lock_time(network.warning_lock_time());

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -777,5 +777,5 @@ pub enum ProtocolErrorKind {
     AddressParse(#[from] bdk_wallet::bitcoin::address::ParseError),
     Transaction(#[from] protocol::transaction::TransactionErrorKind),
     Multisig(#[from] protocol::multisig::MultisigErrorKind),
-    Anyhow(#[from] anyhow::Error),
+    Wallet(#[from] wallet::protocol_wallet_api::WalletErrorKind),
 }

--- a/wallet/src/bmp_wallet.rs
+++ b/wallet/src/bmp_wallet.rs
@@ -28,7 +28,7 @@ use secp::Scalar;
 use crate::chain_data_source::ChainDataSource;
 use crate::coin_selection::{AlwaysSpendImportedFirst, SpendImportedOnly};
 use crate::protocol_wallet_api::{
-    ProtocolWalletApi, WalletExt, finish_standard_psbt, internal_key_at_index,
+    ProtocolWalletApi, WalletErrorKind, WalletExt, finish_standard_psbt, internal_key_at_index,
     sign_selected_inputs_with,
 };
 use crate::utils::{derive_key_from_password, get_salt, trace_logs};
@@ -321,22 +321,22 @@ impl ProtocolWalletApi for BMPWallet<Connection> {
         self.wallet.network()
     }
 
-    fn new_address(&mut self) -> anyhow::Result<Address> {
+    fn new_address(&mut self) -> Result<Address, WalletErrorKind> {
         Ok(self.next_address(KeychainKind::External)?.address)
     }
 
-    fn new_internal_key(&mut self) -> anyhow::Result<XOnlyPublicKey> {
+    fn new_internal_key(&mut self) -> Result<XOnlyPublicKey, WalletErrorKind> {
         // Use `next_address` (gap-filling) rather than `reveal_next_address` directly so
         // that the internal key's index stays in step with what `new_address` would yield.
         let index = self.next_address(KeychainKind::External)?.index;
-        Ok(internal_key_at_index(self, index)?)
+        internal_key_at_index(self, index)
     }
 
     fn create_psbt(
         &mut self,
         recipients: Vec<(ScriptBuf, Amount)>,
         fee_rate: FeeRate,
-    ) -> anyhow::Result<Psbt> {
+    ) -> Result<Psbt, WalletErrorKind> {
         finish_standard_psbt(self.build_tx(), recipients, fee_rate)
     }
 
@@ -344,7 +344,7 @@ impl ProtocolWalletApi for BMPWallet<Connection> {
         &mut self,
         psbt: &mut Psbt,
         is_selected: &dyn Fn(&OutPoint) -> bool,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), WalletErrorKind> {
         // TODO unify signing
         sign_selected_inputs_with(self, psbt, is_selected, |w, p, opts| {
             <Self as WalletApi>::sign(w, p, opts).map_err(Into::into)

--- a/wallet/src/protocol_wallet_api.rs
+++ b/wallet/src/protocol_wallet_api.rs
@@ -10,7 +10,6 @@ use bdk_wallet::bitcoin::{Address, Amount, FeeRate, Network, OutPoint, Psbt, Scr
 use bdk_wallet::coin_selection::CoinSelectionAlgorithm;
 use bdk_wallet::descriptor::{Descriptor, ExtendedDescriptor};
 use bdk_wallet::miniscript::ToPublicKey as _;
-use bdk_wallet::miniscript::descriptor::ConversionError;
 use bdk_wallet::miniscript::psbt::PsbtExt as _;
 use bdk_wallet::template::{Bip86, DescriptorTemplate as _};
 use bdk_wallet::{AddressInfo, KeychainKind, SignOptions, TxBuilder, TxOrdering, Wallet};
@@ -25,14 +24,14 @@ use thiserror::Error;
 pub trait ProtocolWalletApi {
     fn network(&self) -> Network;
 
-    fn new_address(&mut self) -> anyhow::Result<Address>;
+    fn new_address(&mut self) -> Result<Address>;
 
     /// Reveal a fresh external-keychain Taproot internal key. The returned X-only key shall
     /// correspond to a P2TR address that this wallet would otherwise have produced via
     /// [`Self::new_address`] — the two methods are intentionally tied together so that
     /// callers can use either flavour interchangeably and rely on the wallet to keep its
     /// keychain cursor / gap-fill state consistent.
-    fn new_internal_key(&mut self) -> anyhow::Result<XOnlyPublicKey>;
+    fn new_internal_key(&mut self) -> Result<XOnlyPublicKey>;
 
     /// This creates a PSBT for use with the depositTx (but not limited to). You specify the
     /// recipients, consisting of the deposit- (and trade-)amount and spk, and the
@@ -43,13 +42,13 @@ pub trait ProtocolWalletApi {
         &mut self,
         recipients: Vec<(ScriptBuf, Amount)>,
         fee_rate: FeeRate,
-    ) -> anyhow::Result<Psbt>;
+    ) -> Result<Psbt>;
 
     fn sign_selected_inputs(
         &mut self,
         psbt: &mut Psbt,
         is_selected: &dyn Fn(&OutPoint) -> bool,
-    ) -> anyhow::Result<()>;
+    ) -> Result<()>;
 
     // Import an external private from the HD wallet
     // After importing a rescan should be triggered
@@ -69,12 +68,6 @@ pub(crate) static LIBSECP256K1_CTX: LazyLock<secp256k1::Secp256k1<secp256k1::All
     LazyLock::new(secp256k1::Secp256k1::new);
 
 impl MemWallet {
-    pub fn reveal_next_address(&mut self) -> Address {
-        self.wallet
-            .reveal_next_address(KeychainKind::External)
-            .address
-    }
-
     pub fn public_descriptor(&self, chain: KeychainKind) -> &ExtendedDescriptor {
         self.wallet.public_descriptor(chain)
     }
@@ -133,10 +126,11 @@ impl MemWallet {
         self.wallet.balance().trusted_spendable()
     }
 
+    pub fn reveal_next_address(&mut self) -> AddressInfo {
+        self.wallet.reveal_next_address(KeychainKind::External)
+    }
+
     pub fn next_unused_address(&mut self) -> AddressInfo {
-        // FIXME: `next_unused_address` just returns the same unused address over and over. It has
-        //  to either be marked as used (which change isn't staged and therefore presumably never
-        //  persisted) or a fresh address requested with `reveal_next_address`.
         self.wallet.next_unused_address(KeychainKind::External)
     }
 
@@ -154,7 +148,7 @@ impl MemWallet {
     }
 }
 
-pub trait WalletExt {
+pub(crate) trait WalletExt {
     fn update_psbt_with_derivation_paths(&self, psbt: &mut Psbt);
 }
 
@@ -189,49 +183,38 @@ impl WalletExt for MemWallet {
     }
 }
 
+// Delegates to the `ProtocolWalletAPI` impl of the internal wallet.
 impl ProtocolWalletApi for MemWallet {
     fn network(&self) -> Network {
         self.wallet.network()
     }
 
-    fn new_address(&mut self) -> anyhow::Result<Address> {
-        // For privacy, always get fresh addresses for the trade protocol.
-        // FIXME: Need to find a way to prevent gaps of unused addresses from growing too large.
-        Ok(self.reveal_next_address())
+    fn new_address(&mut self) -> Result<Address> {
+        self.wallet.new_address()
     }
 
-    fn new_internal_key(&mut self) -> anyhow::Result<XOnlyPublicKey> {
-        let index = self
-            .wallet
-            .reveal_next_address(KeychainKind::External)
-            .index;
-        Ok(internal_key_at_index(&self.wallet, index)?)
+    fn new_internal_key(&mut self) -> Result<XOnlyPublicKey> {
+        self.wallet.new_internal_key()
     }
 
     fn create_psbt(
         &mut self,
         recipients: Vec<(ScriptBuf, Amount)>,
         fee_rate: FeeRate,
-    ) -> anyhow::Result<Psbt> {
-        finish_standard_psbt(self.wallet.build_tx(), recipients, fee_rate)
+    ) -> Result<Psbt> {
+        self.wallet.create_psbt(recipients, fee_rate)
     }
 
     fn sign_selected_inputs(
         &mut self,
         psbt: &mut Psbt,
         is_selected: &dyn Fn(&OutPoint) -> bool,
-    ) -> anyhow::Result<()> {
-        // TODO unify signing
-        sign_selected_inputs_with(&mut self.wallet, psbt, is_selected, |w, p, opts| {
-            w.sign(p, opts)?;
-            Ok(())
-        })
+    ) -> Result<()> {
+        self.wallet.sign_selected_inputs(psbt, is_selected)
     }
 
-    fn import_private_key(&mut self, _pk: Scalar) {
-        // `MemWallet` is an in-memory wallet that doesn't currently support imported keys.
-        // If/when this is needed, mirror the `BMPWallet` implementation.
-        todo!("MemWallet does not yet support importing private keys")
+    fn import_private_key(&mut self, pk: Scalar) {
+        self.wallet.import_private_key(pk);
     }
 }
 
@@ -240,22 +223,22 @@ impl ProtocolWalletApi for Wallet {
         self.network()
     }
 
-    fn new_address(&mut self) -> anyhow::Result<Address> {
+    fn new_address(&mut self) -> Result<Address> {
         // For privacy, always get fresh addresses for the trade protocol.
         // FIXME: Need to find a way to prevent gaps of unused addresses from growing too large.
         Ok(self.reveal_next_address(KeychainKind::External).address)
     }
 
-    fn new_internal_key(&mut self) -> anyhow::Result<XOnlyPublicKey> {
+    fn new_internal_key(&mut self) -> Result<XOnlyPublicKey> {
         let index = self.reveal_next_address(KeychainKind::External).index;
-        Ok(internal_key_at_index(self, index)?)
+        internal_key_at_index(self, index)
     }
 
     fn create_psbt(
         &mut self,
         recipients: Vec<(ScriptBuf, Amount)>,
         fee_rate: FeeRate,
-    ) -> anyhow::Result<Psbt> {
+    ) -> Result<Psbt> {
         finish_standard_psbt(self.build_tx(), recipients, fee_rate)
     }
 
@@ -263,10 +246,7 @@ impl ProtocolWalletApi for Wallet {
         &mut self,
         psbt: &mut Psbt,
         is_selected: &dyn Fn(&OutPoint) -> bool,
-    ) -> anyhow::Result<()> {
-        if !is_well_formed_psbt(psbt) {
-            anyhow::bail!("PSBT is not well-formed");
-        }
+    ) -> Result<()> {
         // TODO unify signing
         sign_selected_inputs_with(self, psbt, is_selected, |w, p, opts| {
             Self::sign(w, p, opts)?;
@@ -275,8 +255,6 @@ impl ProtocolWalletApi for Wallet {
     }
 
     fn import_private_key(&mut self, _pk: Scalar) {
-        // `bdk_wallet::Wallet` does not support importing external private keys here.
-        // Use `BMPWallet` for that flow.
         unimplemented!(
             "bdk_wallet::Wallet does not support importing external private keys; \
             use BMPWallet for that"
@@ -298,11 +276,14 @@ pub(crate) fn sign_selected_inputs_with<W, F>(
     psbt: &mut Psbt,
     is_selected: &dyn Fn(&OutPoint) -> bool,
     sign: F,
-) -> anyhow::Result<()>
+) -> Result<()>
 where
     W: WalletExt + ?Sized,
     F: FnOnce(&mut W, &mut Psbt, SignOptions) -> anyhow::Result<()>,
 {
+    if !is_well_formed_psbt(psbt) {
+        return Err(WalletErrorKind::MalformedPsbt);
+    }
     let mut psbt_copy = psbt.clone();
     // Populate the BIP32 derivation paths before BDK can finalize the inputs we own. Also
     // tell BDK to trust the witness UTXO since the full previous transactions are not
@@ -341,7 +322,7 @@ pub(crate) fn finish_standard_psbt<Cs: CoinSelectionAlgorithm>(
     mut builder: TxBuilder<'_, Cs>,
     recipients: Vec<(ScriptBuf, Amount)>,
     fee_rate: FeeRate,
-) -> anyhow::Result<Psbt> {
+) -> Result<Psbt> {
     builder
         .ordering(TxOrdering::Untouched)
         .nlocktime(absolute::LockTime::ZERO)
@@ -381,11 +362,18 @@ fn is_well_formed_psbt(psbt: &Psbt) -> bool {
             .all(|i| i.script_sig.is_empty() && i.witness.is_empty())
 }
 
+type Result<T, E = WalletErrorKind> = std::result::Result<T, E>;
+
 #[derive(Error, Debug)]
 #[error(transparent)]
 #[non_exhaustive]
 pub enum WalletErrorKind {
     #[error("not a Taproot address")]
     NotTaprootAddress,
-    ConversionError(#[from] ConversionError),
+    #[error("malformed PSBT")]
+    MalformedPsbt,
+    ConversionError(#[from] bdk_wallet::miniscript::descriptor::ConversionError),
+    CreateTx(#[from] bdk_wallet::error::CreateTxError),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }

--- a/wallet/src/protocol_wallet_api.rs
+++ b/wallet/src/protocol_wallet_api.rs
@@ -183,7 +183,6 @@ impl WalletExt for MemWallet {
     }
 }
 
-// Delegates to the `ProtocolWalletAPI` impl of the internal wallet.
 impl ProtocolWalletApi for MemWallet {
     fn network(&self) -> Network {
         self.wallet.network()
@@ -213,8 +212,10 @@ impl ProtocolWalletApi for MemWallet {
         self.wallet.sign_selected_inputs(psbt, is_selected)
     }
 
-    fn import_private_key(&mut self, pk: Scalar) {
-        self.wallet.import_private_key(pk);
+    fn import_private_key(&mut self, _pk: Scalar) {
+        // `MemWallet` is an in-memory wallet that doesn't currently support imported keys.
+        // If/when this is needed, mirror the `BMPWallet` implementation.
+        todo!("MemWallet does not yet support importing private keys")
     }
 }
 


### PR DESCRIPTION
Implement the stubbed-out `ProtocolWalletAPI::create_pbst` method for `MockTradeWallet`, which the `TradeWallet::create_half_deposit_psbt` method goes through by default, instead of directly overriding it. In this way, `TradeWallet` becomes a (redundant) pure extension trait and can be removed, replacing it's `create_half_deposit_psbt` extension method with a crate-visible utility fn, used only by `DepositTxBuilder`. Replace all uses of `TradeWallet` in the code with `ProtocolWalletAPI`, using `impl/dyn ProtocolWalletAPI` in the interfaces in place of `impl/dyn TradeWallet`.

Also move `MockTradeWallet` and its impls into their own `protocol::mocks` module (for use by some of the unit tests and the `rpc` crate), so that `protocol::psbt` becomes a private utility module (for the tx builders in `protocol::transaction`).

Additionally, fix some of the error handling in `protocol::psbt`, and make `ProtocolWalletAPI` use `Result<T, WalletErrorKind>` for its fallible methods in place of `anyhow`. Also deduplicate the code in the `MemWallet` impl of `ProtocolWalletAPI` slightly, by making it a pure delegate to (the `ProtocolWalletAPI` interface of) its internal BDK wallet.
