### PR TITLE
Add Penalty Tx signing and improve `TradeModel` API safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "argon2"
@@ -129,13 +129,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -325,9 +325,9 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bip157"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14485468baff5ec4114d186f1683635f3094de9f5a4b3953bf82ac6cccba40e8"
+checksum = "cf76493aa2ead2603d435280f4a7bb2413610ff16ddb34f7ec24b090fff51236"
 dependencies = [
  "bip324",
  "bitcoin",
@@ -345,7 +345,7 @@ dependencies = [
  "bitcoin",
  "bitcoin_hashes 0.15.0",
  "chacha20-poly1305",
- "rand 0.8.6",
+ "rand 0.8.7",
  "tokio",
 ]
 
@@ -362,14 +362,13 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.8"
+version = "0.32.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+checksum = "bb0ce8bd5baaa0d303a19915a6d93afed161f528654e42da2a7a97d05c59499a"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
  "bech32",
- "bitcoin-internals 0.3.0",
  "bitcoin-io 0.1.101",
  "bitcoin-units",
  "bitcoin_hashes 0.14.101",
@@ -399,19 +398,12 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+checksum = "207311705279250ba465076a1bac4b1ac982855fff73fc5f67e22158ac58cdc9"
 dependencies = [
- "bitcoin-internals 0.5.0",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
-dependencies = [
+ "bitcoin-internals 0.6.0",
+ "hex-conservative 1.2.0",
  "serde",
 ]
 
@@ -426,9 +418,12 @@ name = "bitcoin-internals"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
-dependencies = [
- "hex-conservative 0.3.2",
-]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
 
 [[package]]
 name = "bitcoin-io"
@@ -436,7 +431,7 @@ version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
 dependencies = [
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
 ]
 
 [[package]]
@@ -454,7 +449,7 @@ version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
 dependencies = [
- "bitcoin-consensus-encoding 1.0.0",
+ "bitcoin-consensus-encoding 1.1.0",
  "serde",
 ]
 
@@ -522,9 +517,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "blake2"
@@ -573,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -622,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -638,9 +633,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20-poly1305"
@@ -673,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -683,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -695,14 +690,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -862,7 +857,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -873,7 +868,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -914,7 +909,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -938,9 +933,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "electrsd"
@@ -968,7 +963,7 @@ dependencies = [
  "byteorder",
  "libc",
  "log",
- "rustls 0.23.41",
+ "rustls 0.23.43",
  "serde",
  "serde_json",
  "webpki-roots",
@@ -1005,9 +1000,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "filetime"
@@ -1064,9 +1059,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1079,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1089,15 +1084,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1106,38 +1101,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1290,6 +1285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1327,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1337,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1362,9 +1366,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1535,9 +1539,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1672,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1695,7 +1699,7 @@ checksum = "183312a1f782d0e27c2e9aa4d68c151301caa39b38f48ea125c1d55ab1ff29f0"
 dependencies = [
  "base16ct",
  "hmac",
- "rand 0.9.4",
+ "rand 0.9.5",
  "secp",
  "secp256k1 0.31.1",
  "sha2",
@@ -1728,7 +1732,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1854,7 +1858,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1947,14 +1951,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1986,7 +1990,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -2000,7 +2004,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2024,10 +2028,10 @@ dependencies = [
  "const_format",
  "musig2",
  "paste",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "testenv",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "wallet",
@@ -2039,7 +2043,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "memchr",
  "unicase",
 ]
@@ -2055,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2076,9 +2080,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2087,9 +2091,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2139,34 +2143,34 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2176,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2221,16 +2225,17 @@ dependencies = [
  "drop-stream",
  "futures-util",
  "guardian",
+ "macro_rules_attribute",
  "musig2",
  "predicates",
  "prost",
  "protocol",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rpc",
  "serde",
  "serde_with",
  "testenv",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -2247,7 +2252,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2261,7 +2266,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2282,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -2297,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
@@ -2339,9 +2344,9 @@ checksum = "68f5acb362a0e75c2a963532fa7fabf13dff81626dc494df16488d30befcbea0"
 
 [[package]]
 name = "scc"
-version = "3.8.4"
+version = "3.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7800bc2c7e91b26aeae70c2ab6eaa653efc133104b7756e674c99304adff3fdb"
+checksum = "f8af0b99483d1c3e59471d4f0cb58b244169436a8979c889a91a3f697075ea01"
 dependencies = [
  "saa",
  "sdd",
@@ -2361,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -2403,7 +2408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ef0ffc3b1b2720b00b919f6c697b1e64aca7bba54b93e0ef4b8560fac6f946"
 dependencies = [
  "base16ct",
- "rand 0.9.4",
+ "rand 0.9.5",
  "secp256k1 0.31.1",
  "subtle",
 ]
@@ -2415,7 +2420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes 0.14.101",
- "rand 0.8.6",
+ "rand 0.8.7",
  "secp256k1-sys 0.10.1",
  "serde",
 ]
@@ -2427,7 +2432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes 0.14.101",
- "rand 0.9.4",
+ "rand 0.9.5",
  "secp256k1-sys 0.11.0",
 ]
 
@@ -2451,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2461,29 +2466,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2505,7 +2510,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -2521,7 +2526,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2562,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -2580,9 +2585,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2602,9 +2607,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2662,7 +2678,7 @@ dependencies = [
  "electrsd",
  "hex",
  "hmac",
- "rand 0.9.4",
+ "rand 0.9.5",
  "secp",
  "sha2",
  "tempfile",
@@ -2682,11 +2698,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -2697,34 +2713,34 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2742,9 +2758,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2752,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2767,9 +2783,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2784,20 +2800,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2806,14 +2822,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -2856,7 +2873,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2881,7 +2898,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.119",
  "tempfile",
  "tonic-build",
 ]
@@ -2936,7 +2953,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2980,13 +2997,13 @@ dependencies = [
 
 [[package]]
 name = "trait-variant"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+checksum = "b19a4867a870f6edc4c283f2b455804b1879c0baf0e642f26b03ed8ee262d9d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3054,7 +3071,7 @@ checksum = "41cf1727a558d3708e0e733b7e6833930876a2358c7e250c70d8a303d36a0694"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3071,9 +3088,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -3120,12 +3137,12 @@ dependencies = [
  "bmp_tracing",
  "chain",
  "hex",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rusqlite",
  "secp",
  "tempfile",
  "testenv",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "trait-variant",
  "zeroize",
@@ -3187,7 +3204,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -3258,7 +3275,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3269,7 +3286,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3402,22 +3419,22 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3441,7 +3458,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.9.5",
  "regex",
  "scc",
  "thiserror 1.0.69",
@@ -3465,6 +3482,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,16 +3,16 @@ resolver = "3"
 members = ["chain", "protocol", "rpc", "wallet", "testenv", "bmp_tracing", "mem"]
 
 [workspace.dependencies]
-anyhow = "1.0.103"
+anyhow = "1.0.104"
 argon2 = { version = "0.5.3", default-features = false }
 base64 = "0.22.1"
 bdk_bitcoind_rpc = "0.22.0"
 bdk_electrum = { version = "0.23.2", default-features = false, features = ["use-rustls-ring"] }
-bdk_kyoto = "0.17"
-bdk_wallet = { version = "3", features = ["rusqlite", "keys-bip39"] }
+bdk_kyoto = "0.17.0"
+bdk_wallet = { version = "3.1.0", features = ["rusqlite", "keys-bip39"] }
 bmp_tracing = { path = "bmp_tracing" }
 chain = { path = "chain" }
-clap = { version = "4.6.1", features = ["derive"] }
+clap = { version = "4.6.5", features = ["derive"] }
 const_format = "0.2.36"
 hex = "0.4.3"
 musig2 = { version = "0.4.1", features = ["rand"] }
@@ -23,15 +23,15 @@ rusqlite = { version = "0.31.0", features = ["bundled-sqlcipher"] }
 secp = "0.7.0"
 tempfile = "3.27.0"
 testenv = { path = "testenv" }
-thiserror = "2.0.18"
-tokio = "1.52.3"
-tokio-stream = "0.1.18"
+thiserror = "2.0.19"
+tokio = "1.53.1"
+tokio-stream = "0.1.19"
 tracing = "0.1.44"
 tracing-core = { version = "0.1.36", default-features = false }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+trait-variant = "0.1.3"
 wallet = { path = "wallet" }
 zeroize = "1.9.0"
-trait-variant = "0.1.2"
 
 [workspace.lints.rust]
 rust-2024-compatibility = "warn"

--- a/bmp_tracing/Cargo.toml
+++ b/bmp_tracing/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2024"
 
 [dependencies]
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 tracing-core = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -5,11 +5,10 @@ edition = "2024"
 
 [dependencies]
 anyhow = { workspace = true }
+bdk_kyoto = { workspace = true }
 bdk_wallet = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-bdk_kyoto = { workspace = true }
-
 
 [lints]
 workspace = true

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -10,10 +10,12 @@ use bdk_wallet::bitcoin::{Transaction, Txid};
 use bdk_wallet::chain::DescriptorId;
 use bdk_wallet::chain::spk_client::{FullScanRequest, FullScanResponse};
 use tokio::select;
+
 /// Minimal abstraction over blockchain interaction for broadcasting transactions.
 pub trait ChainApi: Send + Sync {
     fn transaction_broadcast(&self, tx: &Transaction) -> anyhow::Result<Txid>;
 }
+
 /// Abstraction over the read-side of a chain backend: pre-populating a transaction cache and
 /// performing a full keychain scan. Wallet-level sync routines compose these primitives instead
 /// of taking a hard dependency on a specific chain client (e.g. `BdkElectrumClient`).

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -20,8 +20,8 @@ bdk_wallet = { workspace = true, features = ["test-utils"] }
 bdk_electrum = { workspace = true }
 bmp_tracing = { workspace = true }
 const_format = { workspace = true }
-tokio = { workspace = true }
 testenv = { workspace = true }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/protocol/src/multisig.rs
+++ b/protocol/src/multisig.rs
@@ -170,7 +170,7 @@ pub struct SigCtx {
 }
 
 impl SigCtx {
-    fn tweaked_key_ctx(&self) -> Result<&TweakedKeyCtx> {
+    pub fn tweaked_key_ctx(&self) -> Result<&TweakedKeyCtx> {
         self.tweaked_key_ctx.as_ref().ok_or(MultisigErrorKind::MissingAggPubKey)
     }
 
@@ -206,7 +206,7 @@ impl SigCtx {
         // In order to have a better chance of provable security, don't allow the adaptor point to
         // be set after our local nonce share has already been initialized, as otherwise an attacker
         // may gain too much control over the challenge hash or final adapted signature nonce:
-        if self.my_nonce_pair_share.is_none() {
+        if self.my_nonce_pair_share.is_none() && self.aggregated_sig.is_none() {
             self.adaptor_point = adaptor_point.into();
         }
         match self.adaptor_point {
@@ -234,6 +234,9 @@ impl SigCtx {
     }
 
     pub fn sign_partial(&mut self, message: TapSighash) -> Result<&PartialSignature> {
+        if self.aggregated_sig.is_some() && self.my_partial_sig.is_none() {
+            return Err(MultisigErrorKind::MismatchedSigs);
+        }
         if self.message == Some(message) {
             return self.my_partial_sig();
         }
@@ -283,6 +286,20 @@ impl SigCtx {
         let adaptor_secret: MaybeScalar = adaptor_sig.reveal_secret(&final_sig)
             .ok_or(MultisigErrorKind::MismatchedSigs)?;
         Ok(adaptor_secret.try_into()?)
+    }
+
+    pub fn sign_solo(&mut self, message: TapSighash, peers_prv_key: Scalar) -> Result<&AdaptorSignature> {
+        let tweaked_key_ctx = self.tweaked_key_ctx()?;
+        let mut prv_key_shares = [tweaked_key_ctx.my_prv_key, peers_prv_key];
+        prv_key_shares.sort_by_key(Scalar::base_point_mul);
+        let seckey: Scalar = tweaked_key_ctx.key_agg_ctx.aggregated_seckey(prv_key_shares)?;
+
+        let sig = musig2::deterministic::adaptor::sign_solo(seckey, message, self.adaptor_point);
+        if self.aggregated_sig.is_some_and(|s| s != sig) {
+            return Err(MultisigErrorKind::MismatchedSigs);
+        }
+        self.message = Some(message);
+        Ok(self.aggregated_sig.insert(sig))
     }
 }
 

--- a/protocol/src/protocol_musig_adaptor.rs
+++ b/protocol/src/protocol_musig_adaptor.rs
@@ -94,7 +94,7 @@ pub struct Round4Parameter {
 /// this context is for the whole process and need to be persisted by the caller
 pub struct BMPContext {
     // first of all, everything which is general to the protocol itself.
-    // `funds` is type-erased so the protocol works against any [`TradeWallet`]
+    // `funds` is type-erased so the protocol works against any [`ProtocolWalletApi`]
     // implementation (e.g. `MemWallet`, `BMPWallet`, mocks).
     pub funds: BoxedTradeWallet,
     pub chain: Box<dyn ChainApi>,
@@ -241,17 +241,17 @@ impl BMPProtocol {
             ProtocolRole::Seller => (&self.q_tik, &self.p_tik),
             ProtocolRole::Buyer => (&self.p_tik, &self.q_tik)
         };
-        self.claim_tx_me.build(tik, &self.warning_tx_me)?;
+        self.claim_tx_me.build(other_tik, &self.warning_tx_me)?;
         let claim_alice_nonce = self.claim_tx_me.sig.my_nonce_share()?.clone();
         self.claim_tx_peer.claim_spend = Some(bob.claim_spend);
-        self.claim_tx_peer.build(other_tik, &self.warning_tx_peer)?;
+        self.claim_tx_peer.build(tik, &self.warning_tx_peer)?;
         let claim_bob_nonce = self.claim_tx_peer.sig.my_nonce_share()?.clone();
 
         // RedirectTx
-        self.redirect_tx_me.build(other_tik, &self.warning_tx_peer)?; // RedirectTx overcrosses; Alice references Bob's WarningTx
+        self.redirect_tx_me.build(tik, &self.warning_tx_peer)?; // RedirectTx overcrosses; Alice references Bob's WarningTx
         let redirect_alice_nonce = self.redirect_tx_me.sig.my_nonce_share()?.clone();
         self.redirect_tx_peer.anchor_spend = Some(bob.redirect_anchor_spend);
-        self.redirect_tx_peer.build(tik, &self.warning_tx_me)?;
+        self.redirect_tx_peer.build(other_tik, &self.warning_tx_me)?;
         let redirect_bob_nonce = self.redirect_tx_peer.sig.my_nonce_share()?.clone();
 
         Ok(Round2Parameter {
@@ -510,8 +510,8 @@ impl WarningTx {
 
         //--------------------
         let key_spend = match self.role {
-            ProtocolRole::Seller => q_tik,
-            ProtocolRole::Buyer => p_tik
+            ProtocolRole::Seller => p_tik,
+            ProtocolRole::Buyer => q_tik
         }.with_taproot_tweak(None)?;
 
         let txid = self.builder

--- a/protocol/src/protocol_musig_adaptor.rs
+++ b/protocol/src/protocol_musig_adaptor.rs
@@ -14,8 +14,8 @@ use crate::multisig::{KeyCtx, PointExt as _, SigCtx};
 use crate::receiver::{Receiver, ReceiverList};
 use crate::script_paths;
 use crate::transaction::{
-    ClaimTxBuilder, DepositTxBuilder, RedirectTxBuilder, SwapTxBuilder, TransactionExt as _,
-    WarningTxBuilder,
+    ClaimTxBuilder, DepositTxBuilder, PenaltyTxBuilder, RedirectTxBuilder, SwapTxBuilder,
+    TransactionExt as _, WarningTxBuilder,
 };
 
 /// Type-erased wallet handle used by the trade protocol. The concrete wallet may be a
@@ -115,6 +115,7 @@ pub struct BMPProtocol {
     // which round are we in:
     round: u8,
     pub swap_tx: SwapTx,
+    pub penalty_tx: PenaltyTx,
     pub warning_tx_me: WarningTx,
     warning_tx_peer: WarningTx,
     pub claim_tx_me: ClaimTx,
@@ -158,6 +159,7 @@ impl BMPProtocol {
             deposit_tx: DepositTx::new(),
             round: 0,
             swap_tx: SwapTx::new(role),
+            penalty_tx: PenaltyTx::new(),
             warning_tx_me: WarningTx::new(role),
             warning_tx_peer: WarningTx::new(role.other()),
             claim_tx_me: ClaimTx::new(),
@@ -178,6 +180,7 @@ impl BMPProtocol {
         // ClaimTx
         let claim_spend = self.ctx.funds.new_address()?.script_pubkey();
         self.claim_tx_me.claim_spend = Some(claim_spend.clone());
+        self.penalty_tx.penalty_spend = Some(claim_spend.clone());
 
         // RedirectTx
         let redirect_anchor_spend = self.ctx.funds.new_address()?.script_pubkey();
@@ -253,6 +256,9 @@ impl BMPProtocol {
         self.redirect_tx_peer.anchor_spend = Some(bob.redirect_anchor_spend);
         self.redirect_tx_peer.build(other_tik, &self.warning_tx_me)?;
         let redirect_bob_nonce = self.redirect_tx_peer.sig.my_nonce_share()?.clone();
+
+        // PenaltyTx
+        self.penalty_tx.build(tik, &self.warning_tx_peer)?;
 
         Ok(Round2Parameter {
             p_agg: *self.p_tik.aggregated_key()?.pub_key(),
@@ -460,6 +466,47 @@ impl ClaimTx {
         self.sig.aggregate_partial_signatures()?;
 
         // now stuff those signatures into the transaction
+        self.builder
+            .set_input_signature(self.sig.compute_taproot_signature(MaybeScalar::Zero)?)
+            .compute_signed_tx()?;
+        Ok(())
+    }
+
+    pub fn broadcast(&self, me: &BMPContext) -> anyhow::Result<Txid> {
+        me.chain.transaction_broadcast(self.signed_tx()?)
+    }
+}
+
+/// `PenaltyTx` -- One version for Alice and one for Bob.
+/// Signed unilaterally, so each party only generates and holds their own version.
+#[derive(Default)]
+pub struct PenaltyTx {
+    builder: PenaltyTxBuilder,
+    sig: SigCtx,
+    penalty_spend: Option<ScriptBuf>,
+}
+
+impl PenaltyTx {
+    pub fn new() -> Self { Self::default() }
+
+    pub fn signed_tx(&self) -> anyhow::Result<&Transaction> { Ok(self.builder.signed_tx()?) }
+
+    fn build(&mut self, tik: &KeyCtx, warn_tx: &WarningTx) -> anyhow::Result<()> {
+        self.sig.set_tweaked_key_ctx(tik.with_taproot_tweak(None)?);
+        self.sig.init_my_nonce_share()?;
+
+        self.builder
+            .set_input(warn_tx.builder.escrow()?)
+            .set_payout_address(Address::from_script(self.penalty_spend.as_ref().unwrap(), Network::Regtest)?) // TODO: Improve.
+            .disable_lock_time()
+            .set_fee_rate(FeeRate::from_sat_per_vb_u32(10)) // TODO: feerates shall come from pricenodes
+            .compute_unsigned_tx()?;
+        Ok(())
+    }
+
+    pub fn sign(&mut self, tik: &KeyCtx) -> anyhow::Result<()> {
+        let msg = self.builder.input_sighash()?;
+        self.sig.sign_solo(msg, *tik.my_key_share()?.prv_key()?)?;
         self.builder
             .set_input_signature(self.sig.compute_taproot_signature(MaybeScalar::Zero)?)
             .compute_signed_tx()?;

--- a/protocol/src/protocol_musig_adaptor.rs
+++ b/protocol/src/protocol_musig_adaptor.rs
@@ -14,7 +14,8 @@ use crate::multisig::{KeyCtx, PointExt as _, SigCtx};
 use crate::receiver::{Receiver, ReceiverList};
 use crate::script_paths;
 use crate::transaction::{
-    DepositTxBuilder, ForwardingTxBuilder, RedirectTxBuilder, TransactionExt as _, WarningTxBuilder,
+    ClaimTxBuilder, DepositTxBuilder, RedirectTxBuilder, SwapTxBuilder, TransactionExt as _,
+    WarningTxBuilder,
 };
 
 /// Type-erased wallet handle used by the trade protocol. The concrete wallet may be a
@@ -424,7 +425,7 @@ impl RedirectTx {
 #[derive(Default)]
 pub struct ClaimTx {
     pub sig: SigCtx,
-    pub builder: ForwardingTxBuilder,
+    pub builder: ClaimTxBuilder,
     pub claim_spend: Option<ScriptBuf>,
 }
 
@@ -566,7 +567,7 @@ impl WarningTx {
 pub struct SwapTx {
     // this transaction is only for Alice, however even Bob will construct it for signing:
     pub role: ProtocolRole,
-    pub builder: ForwardingTxBuilder,
+    pub builder: SwapTxBuilder,
     pub swap_spend: Option<ScriptBuf>,
     // SwapTx get funded by a adaptor MuSig2 signature
     pub fund_sig: SigCtx,
@@ -589,7 +590,7 @@ impl SwapTx {
     fn new(role: ProtocolRole) -> Self {
         Self {
             role,
-            builder: ForwardingTxBuilder::default(),
+            builder: SwapTxBuilder::default(),
             swap_spend: None,
             fund_sig: SigCtx::default(),
         }

--- a/protocol/src/state.rs
+++ b/protocol/src/state.rs
@@ -51,6 +51,8 @@ pub enum ClosureType {
 }
 
 impl TradeState {
+    /// All possible trade states, in (non-unique) topological order with respect to the
+    /// [`PartialOrd`] impl of [`TradeState`].
     pub const VALUES: [Self; 16] = [
         Self::Init,
         Self::Deposit,
@@ -127,18 +129,18 @@ impl TradeState {
             Self::Deposit /*                                   -*/ => 0x001, // .. .... ...1
             Self::BuyerReadyToRelease /*                       -*/ => 0x003, // .. .... ..11
             Self::SellerReadyToRelease /*                      -*/ => 0x007, // .. .... .111
-            Self::CustomPayoutSigned /*                        -*/ => 0x013, // .. ...1 ..11
-            Self::BuyersWarning /*                             -*/ => 0x033, // .. ..11 ..11
-            Self::SellersWarning /*                            -*/ => 0x053, // .. .1.1 ..11
-            Self::TradeClosed(ClosureType::Cooperative) /*     -*/ => 0x00f, // .. .... 1111
-            Self::TradeClosed(ClosureType::Forced) /*          -*/ => 0x117, // .1 ...1 .111
-            Self::TradeClosed(ClosureType::Custom) /*          -*/ => 0x093, // .. 1..1 ..11
-            Self::TradeClosed(ClosureType::BuyersRedirect) /*  -*/ => 0x253, // 1. .1.1 ..11
-            Self::TradeClosed(ClosureType::SellersRedirect) /* -*/ => 0x233, // 1. ..11 ..11
-            Self::TradeClosed(ClosureType::BuyersClaim) /*     -*/ => 0x03f, // .. ..11 1111
-            Self::TradeClosed(ClosureType::SellersClaim) /*    -*/ => 0x05f, // .. .1.1 1111
-            Self::TradeClosed(ClosureType::BuyersPenaltyTx) /* -*/ => 0x08f, // .. 1... 1111
-            Self::TradeClosed(ClosureType::SellersPenaltyTx) /*-*/ => 0x10f, // .1 .... 1111
+            Self::CustomPayoutSigned /*                        -*/ => 0x00b, // .. .... 1.11
+            Self::BuyersWarning /*                             -*/ => 0x01b, // .. ...1 1.11
+            Self::SellersWarning /*                            -*/ => 0x02b, // .. ..1. 1.11
+            Self::TradeClosed(ClosureType::Cooperative) /*     -*/ => 0x047, // .. .1.. .111
+            Self::TradeClosed(ClosureType::Forced) /*          -*/ => 0x08f, // .. 1... 1111
+            Self::TradeClosed(ClosureType::Custom) /*          -*/ => 0x10b, // .1 .... 1.11
+            Self::TradeClosed(ClosureType::BuyersRedirect) /*  -*/ => 0x22b, // 1. ..1. 1.11
+            Self::TradeClosed(ClosureType::SellersRedirect) /* -*/ => 0x21b, // 1. ...1 1.11
+            Self::TradeClosed(ClosureType::BuyersClaim) /*     -*/ => 0x05f, // .. .1.1 1111
+            Self::TradeClosed(ClosureType::SellersClaim) /*    -*/ => 0x06f, // .. .11. 1111
+            Self::TradeClosed(ClosureType::BuyersPenaltyTx) /* -*/ => 0x147, // .1 .1.. .111
+            Self::TradeClosed(ClosureType::SellersPenaltyTx) /*-*/ => 0x247, // 1. .1.. .111
         }
     }
 }

--- a/protocol/src/transaction.rs
+++ b/protocol/src/transaction.rs
@@ -515,6 +515,10 @@ pub struct ForwardingTxBuilder {
     signed_tx: Option<Transaction>,
 }
 
+pub type SwapTxBuilder = ForwardingTxBuilder;
+pub type ClaimTxBuilder = ForwardingTxBuilder;
+pub type PenaltyTxBuilder = ForwardingTxBuilder;
+
 impl ForwardingTxBuilder {
     make_getter_setter!(input: TxOutput);
     make_getter_setter!(payout_address: Address);
@@ -921,11 +925,11 @@ mod tests {
     }
 
     //noinspection SpellCheckingInspection
-    fn filled_swap_tx_builder(deposit_tx_builder: &DepositTxBuilder) -> Result<ForwardingTxBuilder> {
+    fn filled_swap_tx_builder(deposit_tx_builder: &DepositTxBuilder) -> Result<SwapTxBuilder> {
         let payout_address = "bcrt1pf5vmdnfx03tlwx0j70cpct8zxpg9upf6p5sgsn624yg4a0lnxwxsegnwnx"
             .parse::<Address<_>>()?.require_network(Network::Regtest)?;
 
-        let mut builder = ForwardingTxBuilder::default();
+        let mut builder = SwapTxBuilder::default();
         builder
             .set_input(deposit_tx_builder.seller_payout()?.clone())
             .set_payout_address(payout_address)
@@ -985,11 +989,11 @@ mod tests {
     }
 
     //noinspection SpellCheckingInspection
-    fn filled_claim_tx_builder(warning_tx_builder: &WarningTxBuilder) -> Result<ForwardingTxBuilder> {
+    fn filled_claim_tx_builder(warning_tx_builder: &WarningTxBuilder) -> Result<ClaimTxBuilder> {
         let payout_address = "bcrt1pf5vmdnfx03tlwx0j70cpct8zxpg9upf6p5sgsn624yg4a0lnxwxsegnwnx"
             .parse::<Address<_>>()?.require_network(Network::Regtest)?;
 
-        let mut builder = ForwardingTxBuilder::default();
+        let mut builder = ClaimTxBuilder::default();
         builder
             .set_input(warning_tx_builder.escrow()?)
             .set_payout_address(payout_address)

--- a/protocol/tests/protocol_integration_tests.rs
+++ b/protocol/tests/protocol_integration_tests.rs
@@ -180,6 +180,22 @@ fn test_warning() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_penalty() -> anyhow::Result<()> {
+    let mut env = TestEnv::new()?;
+    let (mut alice, bob) = initial_tx_creation(&mut env)?;
+    // Trade is cooperatively closed. Alice learns Bob's key on her payout and uses it to
+    // preemptively sign her PenaltyTx.
+    alice.penalty_tx.sign(&bob.q_tik)?;
+    // Now suppose that Bob broadcasts his WarningTx, hoping to fraudulently claim after some delay.
+    bob.warning_tx_me.broadcast(&bob.ctx)?;
+    env.mine_block()?;
+    // Alice notices and broadcasts her PenaltyTx, sending all funds to her.
+    alice.penalty_tx.broadcast(&alice.ctx)?;
+    env.mine_block()?;
+    Ok(())
+}
+
+#[test]
 fn test_claim() -> anyhow::Result<()> {
     let mut env = TestEnv::new()?;
     // env.start_explorer_in_container()?;

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -10,13 +10,13 @@ anyhow = { workspace = true }
 bdk_bitcoind_rpc = { workspace = true }
 bdk_wallet = { workspace = true }
 drop-stream = "0.3.2"
-futures-util = { version = "0.3.32", default-features = false, features = ["alloc"] }
+futures-util = { version = "0.3.33", default-features = false, features = ["alloc"] }
 guardian = "1.3.0"
 musig2 = { workspace = true }
 prost = "0.14.4"
 protocol = { workspace = true }
 rand = { workspace = true }
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { version = "1.0.229", features = ["derive"] }
 serde_with = { version = "3.21.0", features = ["base64", "hex"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
@@ -42,6 +42,8 @@ chain = { workspace = true }
 const_format = { workspace = true }
 predicates = "3.1.4"
 testenv = { workspace = true }
+# Pin transitive 'unimock' dependency, as v0.2.3 replaces 'paste' with less reputable 'pastey' to fix a bogus advisory:
+macro_rules_attribute = "=0.2.2"
 
 [lints]
 workspace = true

--- a/rpc/build.rs
+++ b/rpc/build.rs
@@ -74,7 +74,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             opt_base64("peerOutputPrvKeyShare")
         ])
         .serde_serialized_type("CloseTradeResponse", &[
-            opt_base64("peerOutputPrvKeyShare"), opt_hex("swapTx")
+            opt_base64("peerOutputPrvKeyShare"), opt_hex("swapTx"), opt_hex("penaltyTx")
         ])
         .serde_serialized_type("CustomPayoutPsbt", &[
             base64("psbt")

--- a/rpc/build.rs
+++ b/rpc/build.rs
@@ -71,10 +71,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             hex("tx")
         ])
         .serde_serialized_type("SwapTxSignatureResponse", &[
-            hex("swapTx"), base64("peerOutputPrvKeyShare")
+            opt_base64("peerOutputPrvKeyShare")
         ])
         .serde_serialized_type("CloseTradeResponse", &[
-            base64("peerOutputPrvKeyShare")
+            opt_base64("peerOutputPrvKeyShare"), opt_hex("swapTx")
         ])
         .serde_serialized_type("CustomPayoutPsbt", &[
             base64("psbt")

--- a/rpc/src/main/java/bisq/TradeProtocolClient.java
+++ b/rpc/src/main/java/bisq/TradeProtocolClient.java
@@ -301,6 +301,7 @@ public class TradeProtocolClient {
             var buyersCloseTradeResponse = stub.closeTrade(CloseTradeRequest.newBuilder()
                     .setTradeId(buyerTradeId)
                     .setMyOutputPeersPrvKeyShare(swapTxSignatureResponse.getPeerOutputPrvKeyShare())
+                    .setPenaltyTxFeeRate(3750) // 15.0 sats per vbyte -- optionally set by either trader at closure time
                     .build());
             System.out.println("Got reply: " + buyersCloseTradeResponse);
             // **************************

--- a/rpc/src/main/java/bisq/TradeProtocolClient.java
+++ b/rpc/src/main/java/bisq/TradeProtocolClient.java
@@ -345,7 +345,7 @@ public class TradeProtocolClient {
             // *** BUYER CLOSES TRADE ***
             var buyersCloseTradeResponse = stub.closeTrade(CloseTradeRequest.newBuilder()
                     .setTradeId(buyerTradeId)
-                    .setSwapTx(swapTxSignatureResponse.getSwapTx())
+                    .setSwapTx(sellersCloseTradeResponse.getSwapTx())
                     .build());
             System.out.println("Got reply: " + buyersCloseTradeResponse);
             // **************************

--- a/rpc/src/main/proto/rpc.proto
+++ b/rpc/src/main/proto/rpc.proto
@@ -134,8 +134,8 @@ message SwapTxSignatureRequest {
 }
 
 message SwapTxSignatureResponse {
-  bytes swapTx = 1;
-  bytes peerOutputPrvKeyShare = 2;
+  //bytes swapTx = 1; // removed
+  optional bytes peerOutputPrvKeyShare = 2;
 }
 
 message CloseTradeRequest {
@@ -145,7 +145,8 @@ message CloseTradeRequest {
 }
 
 message CloseTradeResponse {
-  bytes peerOutputPrvKeyShare = 1;
+  optional bytes peerOutputPrvKeyShare = 1;
+  optional bytes swapTx = 2;
 }
 
 message CustomPayoutPsbtRequest {

--- a/rpc/src/main/proto/rpc.proto
+++ b/rpc/src/main/proto/rpc.proto
@@ -142,6 +142,7 @@ message CloseTradeRequest {
   string tradeId = 1;
   optional bytes myOutputPeersPrvKeyShare = 2;
   optional bytes swapTx = 3;
+  optional uint64 penaltyTxFeeRate = 4;
 }
 
 message CloseTradeResponse {

--- a/rpc/src/main/proto/rpc.proto
+++ b/rpc/src/main/proto/rpc.proto
@@ -147,6 +147,7 @@ message CloseTradeRequest {
 message CloseTradeResponse {
   optional bytes peerOutputPrvKeyShare = 1;
   optional bytes swapTx = 2;
+  optional bytes penaltyTx = 3;
 }
 
 message CustomPayoutPsbtRequest {

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -12,8 +12,8 @@ use protocol::multisig::{KeyCtx, KeyPair, PointExt as _, SigCtx};
 use protocol::receiver::{Receiver, ReceiverList};
 use protocol::state::{ClosureType, TradeState};
 use protocol::transaction::{
-    CustomPayoutTxBuilder, DepositTxBuilder, ForwardingTxBuilder, NetworkParams as _,
-    RedirectTxBuilder, TransactionExt as _, WarningTxBuilder,
+    ClaimTxBuilder, CustomPayoutTxBuilder, DepositTxBuilder, NetworkParams as _, RedirectTxBuilder,
+    SwapTxBuilder, TransactionExt as _, WarningTxBuilder,
 };
 use protocol::{mocks, script_paths};
 use thiserror::Error;
@@ -87,7 +87,7 @@ struct DepositTx {
 
 #[derive(Default)]
 struct SwapTx {
-    builder: ForwardingTxBuilder,
+    builder: SwapTxBuilder,
     input_sighash: Option<TapSighash>,
     input_sig_ctx: SigCtx,
 }
@@ -107,7 +107,7 @@ struct RedirectTx {
 
 #[derive(Default)]
 struct ClaimTx {
-    builder: ForwardingTxBuilder,
+    builder: ClaimTxBuilder,
     input_sig_ctx: SigCtx,
 }
 

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -567,7 +567,7 @@ impl TradeModel {
     }
 
     pub fn sign_swap_tx_input_partial(&mut self, sighash: TapSighash) -> Result<()> {
-        let sighash = self.swap_tx.input_sighash.insert(sighash);
+        let sighash = self.swap_tx.input_sighash.get_or_insert(sighash);
         self.swap_tx.input_sig_ctx.sign_partial(*sighash)?;
         Ok(())
     }
@@ -686,11 +686,7 @@ impl TradeModel {
     }
 
     pub fn my_private_key_share_for_peer_output(&self) -> Result<&Scalar> {
-        // TODO: Consider changing the `Musig` gRPC API not to reveal our key share for the peer's
-        //  output if the trade was force-closed (at least if we're the buyer), since otherwise that
-        //  is a belated cooperative closure, but `CustomPayoutSigned -> TradeClosed(Cooperative)`
-        //  is not a legal state transition for the buyer. Then we could tighten access here.
-        access!(self, SellerReadyToRelease | TradeClosed(Forced | Cooperative))?;
+        access!(self, SellerReadyToRelease | TradeClosed(Cooperative))?;
         Ok(self.keys.peers_payout_ctx().my_key_share()?.prv_key()?)
     }
 
@@ -712,11 +708,7 @@ impl TradeModel {
     }
 
     pub fn signed_swap_tx(&self) -> Result<&Transaction> {
-        // TODO: Consider changing the `Musig` gRPC API not to reveal the signed Swap Tx until the
-        //  trade has actually been force-closed, instead of when the seller is ready to release.
-        //  (We don't want the buyer to be able to broadcast the Swap Tx under the seller's feet if
-        //  he didn't intend to force-close it.) Then we could tighten access here.
-        access!(self, SellerReadyToRelease | TradeClosed(Forced))?;
+        access!(self, TradeClosed(Forced))?;
         Ok(self.swap_tx.builder.signed_tx()?)
     }
 
@@ -737,6 +729,12 @@ impl TradeModel {
     }
 
     pub fn set_seller_ready_to_release(&mut self) -> Result<bool> {
+        // NOTE: It is somewhat unsafe for the seller to start closing the trade near to (or after)
+        //  the timelock expiry of the buyer's Warning Tx, since in case of an unresponsive buyer
+        //  and subsequent force-closure, the Swap Tx could then be replaced by it, without the
+        //  seller realising, but the seller won't have a signed Penalty Tx in that case.
+        // TODO: Consider adding a protection against such late closures.
+
         // Regardless of role, make sure we have the Swap Tx final signature before proceeding:
         self.swap_tx.builder.signed_tx()?;
         self.update_state(TradeState::SellerReadyToRelease)

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -261,7 +261,11 @@ impl TradeModel {
             txs.claim.builder.set_fee_rate(fee_rate);
         }
         self.swap_tx.builder.set_fee_rate(fee_rate);
-        self.penalty_tx.builder.set_fee_rate(fee_rate);
+    }
+
+    pub fn set_penalty_tx_fee_rate(&mut self, fee_rate: Option<FeeRate>) -> Result<()> {
+        self.penalty_tx.builder.set_fee_rate(fee_rate.unwrap_or(self.prepared_tx_fee_rate()?));
+        Ok(())
     }
 
     pub fn set_trade_fee_receiver(&mut self, receiver: Option<Receiver<NetworkUnchecked>>) -> Result<()> {
@@ -427,38 +431,27 @@ impl TradeModel {
 
     pub fn compute_unsigned_deposit_tx(&mut self) -> Result<()> {
         self.deposit_tx.builder.compute_unsigned_tx()?;
-        let buyer_payout = self.deposit_tx.builder.buyer_payout()?;
-        let seller_payout = self.deposit_tx.builder.seller_payout()?;
-
-        for txs in [&mut self.buyer_txs, &mut self.seller_txs] {
-            txs.warning.builder
-                .set_buyer_input(buyer_payout.clone())
-                .set_seller_input(seller_payout.clone());
-        }
-        self.swap_tx.builder.set_input(seller_payout.clone());
-        self.custom_payout_tx.builder
-            .set_buyer_input(buyer_payout.clone())
-            .set_seller_input(seller_payout.clone());
         Ok(())
     }
 
     pub fn compute_unsigned_prepared_txs(&mut self) -> Result<()> {
         if !self.am_buyer() {
             // Only the seller has all the params necessary to compute the unsigned swap tx.
+            self.swap_tx.builder.set_input(self.deposit_tx.builder.seller_payout()?.clone());
             self.swap_tx.builder.compute_unsigned_tx()?;
         }
-        let [mut txs, mut peer_txs] = [&mut self.buyer_txs, &mut self.seller_txs];
-        txs.warning.builder.compute_unsigned_tx()?;
-        peer_txs.warning.builder.compute_unsigned_tx()?;
-        for _ in 0..2 {
-            txs.redirect.builder.set_input(peer_txs.warning.builder.escrow()?.clone());
-            txs.redirect.builder.compute_unsigned_tx()?;
-            txs.claim.builder.set_input(txs.warning.builder.escrow()?.clone());
-            txs.claim.builder.compute_unsigned_tx()?;
-            std::mem::swap(&mut txs, &mut peer_txs);
-        }
-        self.penalty_tx.builder.set_input(peer_txs.warning.builder.escrow()?.clone());
-        self.penalty_tx.builder.compute_unsigned_tx()?;
+        self.buyer_txs.compute_unsigned_warning_tx(&self.deposit_tx)?;
+        self.seller_txs.compute_unsigned_warning_tx(&self.deposit_tx)?;
+        self.buyer_txs.compute_unsigned_redirect_and_claim_txs(&self.seller_txs)?;
+        self.seller_txs.compute_unsigned_redirect_and_claim_txs(&self.buyer_txs)?;
+        Ok(())
+    }
+
+    pub fn compute_unsigned_penalty_tx(&mut self) -> Result<()> {
+        let peer_txs = if self.am_buyer() { &self.seller_txs } else { &self.buyer_txs };
+        self.penalty_tx.builder
+            .set_input(peer_txs.warning.builder.escrow()?.clone())
+            .compute_unsigned_tx()?;
         Ok(())
     }
 
@@ -678,7 +671,7 @@ impl TradeModel {
             self.swap_tx.builder.unsigned_tx()?;
             self.swap_tx.input_sig_ctx.my_partial_sig()?;
         }
-        self.penalty_tx.builder.unsigned_tx()?;
+        self.penalty_tx.builder.payout_address()?;
         self.penalty_tx.input_sig_ctx.tweaked_key_ctx()?;
         // Now sign the Deposit Tx. It is CRITICAL that we don't share the PSBT or signed tx until
         // the trade state has successfully advanced past `Init` to `Deposit`.
@@ -814,6 +807,8 @@ impl TradeModel {
 
     pub fn compute_custom_payout_tx(&mut self) -> Result<()> {
         self.custom_payout_tx.builder
+            .set_buyer_input(self.deposit_tx.builder.buyer_payout()?.clone())
+            .set_seller_input(self.deposit_tx.builder.seller_payout()?.clone())
             .set_buyer_payout_address(self.buyer_txs.claim.builder.payout_address()?.clone())
             .set_seller_payout_address(self.seller_txs.claim.builder.payout_address()?.clone())
             .compute_unsigned_tx()?;
@@ -838,6 +833,26 @@ impl TradeModel {
     pub fn signed_custom_payout_tx(&self) -> Result<Transaction> {
         access!(self, CustomPayoutSigned | TradeClosed(Custom))?;
         Ok(self.custom_payout_tx.builder.signed_tx()?)
+    }
+}
+
+impl ArbitrationTxs {
+    fn compute_unsigned_warning_tx(&mut self, deposit_tx: &DepositTx) -> Result<()> {
+        self.warning.builder
+            .set_buyer_input(deposit_tx.builder.buyer_payout()?.clone())
+            .set_seller_input(deposit_tx.builder.seller_payout()?.clone())
+            .compute_unsigned_tx()?;
+        Ok(())
+    }
+
+    fn compute_unsigned_redirect_and_claim_txs(&mut self, peer: &Self) -> Result<()> {
+        self.redirect.builder
+            .set_input(peer.warning.builder.escrow()?.clone())
+            .compute_unsigned_tx()?;
+        self.claim.builder
+            .set_input(self.warning.builder.escrow()?.clone())
+            .compute_unsigned_tx()?;
+        Ok(())
     }
 }
 

--- a/rpc/src/protocol.rs
+++ b/rpc/src/protocol.rs
@@ -12,8 +12,8 @@ use protocol::multisig::{KeyCtx, KeyPair, PointExt as _, SigCtx};
 use protocol::receiver::{Receiver, ReceiverList};
 use protocol::state::{ClosureType, TradeState};
 use protocol::transaction::{
-    ClaimTxBuilder, CustomPayoutTxBuilder, DepositTxBuilder, NetworkParams as _, RedirectTxBuilder,
-    SwapTxBuilder, TransactionExt as _, WarningTxBuilder,
+    ClaimTxBuilder, CustomPayoutTxBuilder, DepositTxBuilder, NetworkParams as _, PenaltyTxBuilder,
+    RedirectTxBuilder, SwapTxBuilder, TransactionExt as _, WarningTxBuilder,
 };
 use protocol::{mocks, script_paths};
 use thiserror::Error;
@@ -51,6 +51,7 @@ pub struct TradeModel {
     keys: Keys,
     deposit_tx: DepositTx,
     swap_tx: SwapTx,
+    penalty_tx: PenaltyTx,
     custom_payout_tx: CustomPayoutTx,
     buyer_txs: ArbitrationTxs,
     seller_txs: ArbitrationTxs,
@@ -108,6 +109,12 @@ struct RedirectTx {
 #[derive(Default)]
 struct ClaimTx {
     builder: ClaimTxBuilder,
+    input_sig_ctx: SigCtx,
+}
+
+#[derive(Default)]
+struct PenaltyTx {
+    builder: PenaltyTxBuilder,
     input_sig_ctx: SigCtx,
 }
 
@@ -199,6 +206,7 @@ impl TradeModel {
             txs.claim.builder.set_lock_time(network.claim_lock_time());
         }
         trade_model.swap_tx.builder.disable_lock_time();
+        trade_model.penalty_tx.builder.disable_lock_time();
         trade_model.keys.am_buyer = trade_model.am_buyer();
         trade_model
     }
@@ -253,6 +261,7 @@ impl TradeModel {
             txs.claim.builder.set_fee_rate(fee_rate);
         }
         self.swap_tx.builder.set_fee_rate(fee_rate);
+        self.penalty_tx.builder.set_fee_rate(fee_rate);
     }
 
     pub fn set_trade_fee_receiver(&mut self, receiver: Option<Receiver<NetworkUnchecked>>) -> Result<()> {
@@ -278,7 +287,9 @@ impl TradeModel {
     pub fn init_my_key_shares(&mut self) -> Result<()> {
         self.keys.buyer_payout_ctx.init_my_key_share();
         self.keys.seller_payout_ctx.init_my_key_share();
-        self.keys.my_multisig_script_key.get_or_insert(self.trade_wallet()?.new_internal_key()?);
+        if self.keys.my_multisig_script_key.is_none() {
+            self.keys.my_multisig_script_key = Some(self.trade_wallet()?.new_internal_key()?);
+        }
         Ok(())
     }
 
@@ -340,6 +351,12 @@ impl TradeModel {
         self.buyer_txs.warning.builder.set_escrow_address(buyers_warning_escrow_address);
         self.seller_txs.warning.builder.set_escrow_address(sellers_warning_escrow_address);
 
+        self.penalty_tx.input_sig_ctx.set_tweaked_key_ctx(if self.am_buyer() {
+            &sellers_warning_escrow_tweaked_key_ctx
+        } else {
+            &buyers_warning_escrow_tweaked_key_ctx
+        }.clone());
+
         self.buyer_txs.claim.input_sig_ctx.set_tweaked_key_ctx(buyers_warning_escrow_tweaked_key_ctx.clone());
         self.seller_txs.redirect.input_sig_ctx.set_tweaked_key_ctx(buyers_warning_escrow_tweaked_key_ctx);
         self.seller_txs.claim.input_sig_ctx.set_tweaked_key_ctx(sellers_warning_escrow_tweaked_key_ctx.clone());
@@ -348,15 +365,18 @@ impl TradeModel {
     }
 
     pub fn init_my_addresses(&mut self) -> Result<()> {
-        let mut wallet = self.trade_wallet()?;
-        let my_txs = if self.am_buyer() { &mut self.buyer_txs } else { &mut self.seller_txs };
-        my_txs.warning.builder.set_anchor_address(wallet.new_address()?);
-        my_txs.redirect.builder.set_anchor_address(wallet.new_address()?);
-        my_txs.claim.builder.set_payout_address(wallet.new_address()?);
-        if !self.am_buyer() {
-            self.swap_tx.builder.set_payout_address(wallet.new_address()?);
+        if self.penalty_tx.builder.payout_address().is_err() {
+            let mut wallet = self.trade_wallet()?;
+            if !self.am_buyer() {
+                self.swap_tx.builder.set_payout_address(wallet.new_address()?);
+            }
+            let my_txs = if self.am_buyer() { &mut self.buyer_txs } else { &mut self.seller_txs };
+            my_txs.warning.builder.set_anchor_address(wallet.new_address()?);
+            my_txs.redirect.builder.set_anchor_address(wallet.new_address()?);
+            my_txs.claim.builder.set_payout_address(wallet.new_address()?);
+            self.penalty_tx.builder.set_payout_address(my_txs.claim.builder.payout_address()?.clone());
+            drop(wallet);
         }
-        drop(wallet);
         Ok(())
     }
 
@@ -379,10 +399,12 @@ impl TradeModel {
     }
 
     pub fn init_my_half_deposit_psbt(&mut self) -> Result<()> {
-        if self.am_buyer() {
-            self.deposit_tx.builder.init_buyers_half_psbt(&mut *self.trade_wallet()?, &mut rand::rng())?;
-        } else {
-            self.deposit_tx.builder.init_sellers_half_psbt(&mut *self.trade_wallet()?, &mut rand::rng())?;
+        if self.my_half_deposit_psbt().is_err() {
+            if self.am_buyer() {
+                self.deposit_tx.builder.init_buyers_half_psbt(&mut *self.trade_wallet()?, &mut rand::rng())?;
+            } else {
+                self.deposit_tx.builder.init_sellers_half_psbt(&mut *self.trade_wallet()?, &mut rand::rng())?;
+            }
         }
         Ok(())
     }
@@ -435,6 +457,8 @@ impl TradeModel {
             txs.claim.builder.compute_unsigned_tx()?;
             std::mem::swap(&mut txs, &mut peer_txs);
         }
+        self.penalty_tx.builder.set_input(peer_txs.warning.builder.escrow()?.clone());
+        self.penalty_tx.builder.compute_unsigned_tx()?;
         Ok(())
     }
 
@@ -650,7 +674,12 @@ impl TradeModel {
         my_txs.claim.builder.signed_tx()?;
         if self.am_buyer() {
             self.swap_tx.input_sig_ctx.aggregated_sig()?;
+        } else {
+            self.swap_tx.builder.unsigned_tx()?;
+            self.swap_tx.input_sig_ctx.my_partial_sig()?;
         }
+        self.penalty_tx.builder.unsigned_tx()?;
+        self.penalty_tx.input_sig_ctx.tweaked_key_ctx()?;
         // Now sign the Deposit Tx. It is CRITICAL that we don't share the PSBT or signed tx until
         // the trade state has successfully advanced past `Init` to `Deposit`.
         if self.am_buyer() {
@@ -722,6 +751,19 @@ impl TradeModel {
         Ok(())
     }
 
+    pub fn compute_signed_penalty_tx(&mut self) -> Result<()> {
+        self.penalty_tx.input_sig_ctx.sign_solo(self.penalty_tx.builder.input_sighash()?,
+            *self.keys.my_payout_ctx_mut().peers_key_share()?.prv_key()?)?;
+        self.penalty_tx.builder
+            .set_input_signature(self.penalty_tx.input_sig_ctx.compute_taproot_signature(MaybeScalar::Zero)?)
+            .compute_signed_tx()?;
+        Ok(())
+    }
+
+    pub fn signed_penalty_tx(&self) -> Result<&Transaction> {
+        Ok(self.penalty_tx.builder.signed_tx()?)
+    }
+
     pub fn set_buyer_ready_to_release(&mut self) -> Result<bool> {
         // Regardless of role, make sure we have the Swap Tx adaptor signature before proceeding:
         self.swap_tx.input_sig_ctx.aggregated_sig()?;
@@ -749,6 +791,7 @@ impl TradeModel {
             ClosureType::Cooperative | ClosureType::Forced => {
                 // TODO: Should export the private key to the wallet, not just check we've got it:
                 self.keys.my_payout_ctx_mut().aggregated_key()?.prv_key()?;
+                self.penalty_tx.builder.signed_tx()?;
                 // TODO: If forced closure, make sure we've seen the Swap Tx on the network.
             }
             ClosureType::Custom => {

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -173,20 +173,16 @@ impl musig_server::Musig for MusigImpl {
                 return Err(Status::failed_precondition("operation only available for seller"));
             }
             if request.seller_ready_to_release {
+                trade_model.compute_signed_swap_tx()?;
                 trade_model.set_seller_ready_to_release()?;
-                let swap_tx = trade_model.signed_swap_tx()?;
                 let prv_key_share = trade_model.my_private_key_share_for_peer_output()?;
 
-                Ok(SwapTxSignatureResponse {
-                    swap_tx: consensus::serialize(swap_tx),
-                    peer_output_prv_key_share: prv_key_share.serialize().into(),
-                })
+                Ok(SwapTxSignatureResponse { peer_output_prv_key_share: Some(prv_key_share.serialize().into()) })
             } else {
                 trade_model.set_swap_tx_input_peers_partial_signature(
                     request.swap_tx_input_peers_partial_signature.try_proto_into()?);
                 trade_model.aggregate_swap_tx_partial_signatures()?;
                 trade_model.set_buyer_ready_to_release()?;
-                trade_model.compute_signed_swap_tx()?;
 
                 Ok(SwapTxSignatureResponse::default())
             }
@@ -214,9 +210,13 @@ impl musig_server::Musig for MusigImpl {
 
                 info!("*** BROADCAST SWAP TX ***"); // TODO: Implement broadcast.
             }
-            let my_prv_key_share = trade_model.my_private_key_share_for_peer_output()?;
+            let my_prv_key_share = trade_model.my_private_key_share_for_peer_output().ok();
+            let swap_tx = trade_model.signed_swap_tx().ok();
 
-            Ok(CloseTradeResponse { peer_output_prv_key_share: my_prv_key_share.serialize().into() })
+            Ok(CloseTradeResponse {
+                peer_output_prv_key_share: my_prv_key_share.map(|s| s.serialize().into()),
+                swap_tx: swap_tx.map(consensus::serialize),
+            })
         })
     }
 

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -192,6 +192,9 @@ impl musig_server::Musig for MusigImpl {
     #[instrument(skip_all)]
     async fn close_trade(&self, request: Request<CloseTradeRequest>) -> Result<Response<CloseTradeResponse>> {
         handle_musig_request(request, move |request, trade_model| {
+            let penalty_tx_fee_rate = request.penalty_tx_fee_rate.map(u64::check_in_signed_range).transpose()?;
+            trade_model.set_penalty_tx_fee_rate(penalty_tx_fee_rate.map(FeeRate::from_sat_per_kwu))?;
+            trade_model.compute_unsigned_penalty_tx()?;
             if let Some(peer_prv_key_share) = request.my_output_peers_prv_key_share.try_proto_into()? {
                 // Trader receives the private key share from a cooperative peer, closing our trade.
                 trade_model.set_peer_private_key_share_for_my_output(peer_prv_key_share)?;

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -196,12 +196,14 @@ impl musig_server::Musig for MusigImpl {
                 // Trader receives the private key share from a cooperative peer, closing our trade.
                 trade_model.set_peer_private_key_share_for_my_output(peer_prv_key_share)?;
                 trade_model.aggregate_private_keys_for_my_output()?;
+                trade_model.compute_signed_penalty_tx()?;
                 trade_model.close_trade(ClosureType::Cooperative)?;
             } else if let Some(swap_tx) = request.swap_tx.try_proto_into()? {
                 // Buyer supplies a signed swap tx to the Rust server, to close our trade. (Mainly for
                 // testing -- normally the tx would be picked up from the bitcoin network by the server.)
                 trade_model.recover_seller_private_key_share_for_buyer_output(&swap_tx)?;
                 trade_model.aggregate_private_keys_for_my_output()?;
+                trade_model.compute_signed_penalty_tx()?;
                 trade_model.close_trade(ClosureType::Forced)?;
             } else {
                 // Peer unresponsive -- force-close our trade by publishing the swap tx. For seller only.
@@ -211,11 +213,15 @@ impl musig_server::Musig for MusigImpl {
                 info!("*** BROADCAST SWAP TX ***"); // TODO: Implement broadcast.
             }
             let my_prv_key_share = trade_model.my_private_key_share_for_peer_output().ok();
+            // We could use `oneof` in the proto for these fields, instead of a (wire-compatible)
+            // pair of optionals, but that makes the Prost bindings awkward to use:
             let swap_tx = trade_model.signed_swap_tx().ok();
+            let penalty_tx = trade_model.signed_penalty_tx().ok().filter(|_| swap_tx.is_none());
 
             Ok(CloseTradeResponse {
                 peer_output_prv_key_share: my_prv_key_share.map(|s| s.serialize().into()),
                 swap_tx: swap_tx.map(consensus::serialize),
+                penalty_tx: penalty_tx.map(consensus::serialize),
             })
         })
     }

--- a/testenv/Cargo.toml
+++ b/testenv/Cargo.toml
@@ -9,7 +9,6 @@ anyhow = { workspace = true }
 bdk_bitcoind_rpc = { workspace = true }
 bdk_electrum = { workspace = true }
 bdk_wallet = { workspace = true, features = ["test-utils"] }
-wallet = { path = "../wallet"}
 bmp_tracing = { workspace = true }
 chain = { workspace = true }
 clap = { workspace = true }
@@ -18,6 +17,7 @@ rand = { workspace = true }
 secp = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["net", "signal", "rt"] }
+wallet = { workspace = true }
 
 ctrlc = "3.5.2"
 electrsd = { version = "0.36.1", features = [

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -17,14 +17,14 @@ rusqlite = { workspace = true }
 secp = { workspace = true }
 tracing = { workspace = true }
 zeroize = { workspace = true }
-thiserror =  { workspace = true }
-trait-variant = { workspace =  true }
+thiserror = { workspace = true }
+trait-variant = { workspace = true }
 
 [dev-dependencies]
 bdk_wallet = { workspace = true, features = ["test-utils"] }
 bmp_tracing = { workspace = true }
 tempfile = { workspace = true }
-testenv = { path = "../testenv"}
+testenv = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Add static/prepared Penalty Tx construction and signing to `rpc::protocol::TradeModel`, reusing the Claim payout address and the prepared tx feerate agreed at the trade start. The Penalty Tx is signed upon cooperative trade closure (or if the buyer sees the seller's Swap Tx), that is, once the full aggregated private key for our payout is learned. Pass the signed Penalty Tx to the Java client in an added `CloseTradeResponse.penaltyTx` proto field (for optional watchtower use).

Make a few other changes to `rpc.proto` to address a couple of security-related TODOs in the `TradeModel` impl, improving the API safety by tightening access to the `signed_swap_tx` and `my_private_key_share_for_peer_output` getters. This involves moving the `swapTx` proto field one message later from `SwapTxSignatureResponse` (second call, when the seller decides to release the escrow) to `CloseTradeResponse` (when the seller actually force-closes the trade), and also making `CloseTradeResponse.peerOutputPrvKeyShare` optional, so that the buyer does _not_ reveal his key share in the case that the trade was force-closed by the seller. Even though these are technically breaking changes to the `Musig` API, it doesn't break the Bisq2 client since it hasn't implemented the force-closure path yet.

Also make the wallet-mutating methods of `TradeModel` idempotent to minimise potential unused address churn, in the same pattern as making its other methods idempotent where possible.

--

Add an indirect integration test for the Penalty path by implementing it in `protocol::protocol_musig_adapter` as well (and making an associated fix there to the use of `p_tik` vs `q_tik` for the Warning escrows), and adding a test case to `protocol_integration_tests`.

--

Finally, make some assorted minor changes, such as using somewhat less arbitrary choices of the bit patterns in `protocol::TradeState::bits` that are closer to the adjacency matrix of the partial order. (I could have made the bit patterns exactly equal to the adjacency matrix and that would have also worked, but they would be non-minimal length.) Also tidy the Cargo manifests a little and bump the dependencies.

--

- ~~**TODO:** Following discussion at the team meeting, it may be better to pass the chosen Penalty Tx feerate from the client to the Rust server at trade closure time, as it will be less out-of-date than the generic prepared tx feerate decided at the trade start, by the time the Penalty Tx actually has to be used. This should be a fairly easy change, I think.~~
